### PR TITLE
Fix playground build when a new component is added

### DIFF
--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -12,9 +12,6 @@ export default defineConfig({
       plugins: [tailwindcss('../packages/theme/tailwind.config.js')],
     },
   },
-  optimizeDeps: {
-    include: ['@puik/components'],
-  },
   resolve: {
     preserveSymlinks: true,
     alias: [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### ❓ Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] 📦 New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there any PR to sync with ? -->
When a new component is added the playground doesn't reload the @puik/component local package which throws the following error in the js console
```
Uncaught SyntaxError: The requested module '/node_modules/.vite/@puik_components.js?v=7996d434' does not provide an export named 'PuikCheckbox'
```
This issue is caused by pre-bundling the @puik/component package with vite we can fix this issue by removing the optimizeDeps.includes from the vite.config.ts 

### 📝 Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes
