### PR TITLE
feat: tooltip can be deactived and add z index

### DIFF
--- a/packages/components/tooltip/src/tooltip.ts
+++ b/packages/components/tooltip/src/tooltip.ts
@@ -22,6 +22,16 @@ export const tooltipProps = buildProps({
     required: false,
     default: 'top',
   },
+  isDisabled: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+  zindex: {
+    type: Number,
+    required: false,
+    default: 1000,
+  },
 } as const)
 
 export type TooltipProps = ExtractPropTypes<typeof tooltipProps>

--- a/packages/components/tooltip/src/tooltip.vue
+++ b/packages/components/tooltip/src/tooltip.vue
@@ -8,7 +8,14 @@
     <div ref="tooltipWrapper">
       <slot></slot>
     </div>
-    <div :id="id" ref="tooltip" class="puik-tooltip__tip" role="tooltip">
+    <div
+      v-show="!isDisabled"
+      :id="id"
+      ref="tooltip"
+      class="puik-tooltip__tip"
+      role="tooltip"
+      :style="{ 'z-index': zindex }"
+    >
       <span v-if="$slots.title || title" class="puik-tooltip__tip__title"
         ><slot name="title">{{ title }}</slot></span
       >

--- a/packages/components/tooltip/stories/tooltip.stories.ts
+++ b/packages/components/tooltip/stories/tooltip.stories.ts
@@ -18,12 +18,36 @@ export default {
       control: 'select',
       description: 'Set the tooltip position',
       options: tooltipPosition,
+      table: {
+        defaultValue: {
+          summary: 'top',
+        },
+      },
+    },
+    isDisabled: {
+      control: 'boolean',
+      description: 'Enable or disable the tooltip',
+      table: {
+        defaultValue: {
+          summary: 'false',
+        },
+      },
+    },
+    zindex: {
+      control: 'number',
+      description: 'Set the z-index level',
+      table: {
+        defaultValue: {
+          summary: '1000',
+        },
+      },
     },
   },
   args: {
     title: 'Title',
     description: 'This is a tooltip',
     position: 'top',
+    isActive: true,
   },
 } as Meta
 
@@ -47,6 +71,21 @@ const Template: Story = (args: Args) => ({
 
 export const Default = Template.bind({})
 Default.args = {}
+
+export const DisabledTooltip = () => ({
+  components: {
+    PuikTooltip,
+    PuikButton,
+  },
+  template: `
+    <div style="display: flex; align-items: center; justify-content: center; height: 320px;">
+      <puik-tooltip :is-disabled="true" position="top">
+        <puik-button>There is no tooltip</puik-button>
+        <template #title>Title</template>
+        <template #description>This tooltip is on a button</template>
+      </puik-tooltip>
+    </div>`,
+})
 
 export const UsingAComponent = () => ({
   components: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
I want to display a tooltip only when my text is ellipsed so I added an attribute `isActive` (default value = true) allowing us to choose if we want to display the tooltip or not without hidding the default slot.
And I added a z-index 50 to be sure that the tooltip will be over all.

### ❓ Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] 📦 New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!--- Describe your changes in detail -->
I want to display a tooltip only when my text is ellipsed so I added an attribute `isActive` (default value = true) allowing us to chose if we want to display the tooltip or not without hidding the default slot  :p
<!--- Why is this change required? What problem does it solve? -->
Problem solved:
I have an order title and I want to display the tooltip only when it is ellipsed to show the full text
<!--- Is there any PR to sync with ? -->

### 📝 Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes
