### PR TITLE
[Fix]: Add default value to inject in PuikButton

### DIFF
--- a/packages/components/button/src/button.vue
+++ b/packages/components/button/src/button.vue
@@ -38,7 +38,7 @@ defineOptions({
 })
 
 const props = defineProps(buttonProps)
-const buttonGroup = inject(ButtonGroupKey)
+const buttonGroup = inject(ButtonGroupKey, undefined)
 
 const componentType = computed(() => {
   if (props.to) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### ❓ Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] 📦 New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there any PR to sync with ? -->
When the PuikButton is used without PuikButtonGroup, the following vue warn was displayed in the console 
```
[Vue warn]: injection "Symbol(ButtonGroup)" not found.
```
Adding a default value to the inject in the button has resolved the issue

### 📝 Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes
