### PR TITLE
[Style]: change hover and active colors of secondary button

### DIFF
--- a/packages/theme/src/button.scss
+++ b/packages/theme/src/button.scss
@@ -65,10 +65,10 @@
   &--secondary {
     @apply bg-white text-primary border border-primary;
     &:hover {
-      @apply bg-primary-200;
+      @apply bg-primary-300;
     }
     &:active {
-      @apply bg-primary-300;
+      @apply bg-primary-400;
     }
     &:disabled,
     &.puik-button--disabled {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### ❓ Types of changes

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] 📦 New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Hover state is not visible enough on gray background : https://www.notion.so/prestashopcorp/Secondary-button-hover-is-not-visible-c54a16a4b7534f5eb690d61b0bf8f860

### 📝 Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes
