### PR TITLE
[FIX] Use correct autofill colors for input & select components

### DIFF
--- a/packages/theme/src/input.scss
+++ b/packages/theme/src/input.scss
@@ -26,7 +26,7 @@
       disabled:text-primary-500 disabled:cursor-not-allowed
       placeholder:text-primary-700 placeholder:disabled:text-primary-500;
     &:-webkit-autofill {
-      -webkit-box-shadow: 0 0 0 50px #e9e6f8 inset;
+      -webkit-box-shadow: 0 0 0 50px theme('colors.ocean-blue.50') inset;
     }
     &[type='number'] {
       -moz-appearance: textfield;

--- a/packages/theme/src/select.scss
+++ b/packages/theme/src/select.scss
@@ -21,7 +21,7 @@
       placeholder:text-primary
       disabled:placeholder:text-primary-500;
     &:-webkit-autofill {
-      -webkit-box-shadow: 0 0 0 50px #e9e6f8 inset;
+      -webkit-box-shadow: 0 0 0 50px theme('colors.ocean-blue.50') inset;
     }
   }
   &__icon {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### ❓ Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] 📦 New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there any PR to sync with ? -->
Before this PR when the input & the select component are autofilled by the browser the background of the component was purple, this PR aims to change this background to `ocean-blue-50`

### 📝 Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes
