### PR TITLE
fix: icon alignement in button

### DIFF
--- a/packages/theme/src/button.scss
+++ b/packages/theme/src/button.scss
@@ -2,15 +2,15 @@
 
 .puik-button {
   @extend .puik-text-button-default;
-  @apply transition cursor-pointer py-2 px-4 inline-flex items-center justify-center align-middle;
+  @apply transition cursor-pointer py-2 px-4 gap-2 inline-flex items-center justify-center align-middle;
 
   &--sm {
     @extend .puik-text-button-small;
-    @apply py-1 px-2 gap-2 h-7;
+    @apply py-1 px-2 h-7;
   }
 
   &--md {
-    @apply gap-2 h-9;
+    @apply h-9;
   }
 
   &--lg {

--- a/packages/theme/src/button.scss
+++ b/packages/theme/src/button.scss
@@ -2,37 +2,20 @@
 
 .puik-button {
   @extend .puik-text-button-default;
-  @apply transition cursor-pointer py-2.5 px-4;
+  @apply transition cursor-pointer py-2 px-4 inline-flex items-center justify-center align-middle;
 
   &--sm {
     @extend .puik-text-button-small;
-    @apply py-1 px-2;
-    .puik-button__left-icon {
-      @apply mr-2;
-    }
-    .puik-button__right-icon {
-      @apply ml-2;
-    }
+    @apply py-1 px-2 gap-2;
   }
 
   &--md {
-    .puik-button__left-icon {
-      @apply mr-2;
-    }
-    .puik-button__right-icon {
-      @apply ml-2;
-    }
+    @apply gap-2;
   }
 
   &--lg {
     @extend .puik-text-button-large;
-    @apply py-3.5 px-4;
-    .puik-button__left-icon {
-      @apply mr-3;
-    }
-    .puik-button__right-icon {
-      @apply ml-3;
-    }
+    @apply py-3.5 px-4 gap-3;
   }
 
   &--fluid {
@@ -176,6 +159,6 @@
 
   &__left-icon,
   &__right-icon {
-    @apply font-materialIcons align-middle leading-[0];
+    @apply font-materialIcons align-middle;
   }
 }

--- a/packages/theme/src/button.scss
+++ b/packages/theme/src/button.scss
@@ -6,16 +6,16 @@
 
   &--sm {
     @extend .puik-text-button-small;
-    @apply py-1 px-2 gap-2;
+    @apply py-1 px-2 gap-2 h-7;
   }
 
   &--md {
-    @apply gap-2;
+    @apply gap-2 h-9;
   }
 
   &--lg {
     @extend .puik-text-button-large;
-    @apply py-3.5 px-4 gap-3;
+    @apply py-3.5 px-4 gap-3 h-12;
   }
 
   &--fluid {

--- a/packages/theme/src/common/typography.scss
+++ b/packages/theme/src/common/typography.scss
@@ -93,7 +93,7 @@
 // Buttons
 
 .puik-text-button-default {
-  @apply font-primary font-semibold text-sm leading-4;
+  @apply font-primary font-semibold text-sm leading-[1.125rem];
 }
 
 .puik-text-button-small {
@@ -101,5 +101,5 @@
 }
 
 .puik-text-button-large {
-  @apply font-primary text-base leading-6 font-semibold;
+  @apply font-primary text-base leading-5 font-semibold;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### ❓ Types of changes
Fix the alignement of icons inside Button
Set fixed height for button to fix border overflow and icon displacement

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] 📦 New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there any PR to sync with ? -->
<!--- The component exists on old Prestashop UIKit ? Please create pull request on [migrating documentation](https://github.com/PrestaShopCorp/devdocs.uikit.prestashop.com) to help for migration.  -->
https://www.notion.so/prestashopcorp/Icons-on-buttons-are-not-aligned-add7359139fa47c8bd4d1b290a45dd73

### 📝 Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes
- [ ] The component exists on old Prestashop UIKit and my pull request on [migrating documentation](https://github.com/PrestaShopCorp/devdocs.uikit.prestashop.com) is accepted.
