### PR TITLE
fix: add animation pause on chromatic snapshot

### DIFF
--- a/docs/.storybook/preview.js
+++ b/docs/.storybook/preview.js
@@ -2,6 +2,7 @@ import '../assets/css/index.css'
 import '@puik/theme/src/index.scss'
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
+  chromatic: { pauseAnimationAtEnd: true },
   controls: {
     expanded: true,
     matchers: {

--- a/packages/components/spinner-loader/stories/spinner-loader.stories.ts
+++ b/packages/components/spinner-loader/stories/spinner-loader.stories.ts
@@ -68,9 +68,6 @@ export default {
     label: '',
     color: 'primary',
   },
-  parameters: {
-    chromatic: { pauseAnimationAtEnd: true },
-  },
 } as Meta
 
 const Template: Story = (args: Args, storyContext) => ({

--- a/packages/components/spinner-loader/stories/spinner-loader.stories.ts
+++ b/packages/components/spinner-loader/stories/spinner-loader.stories.ts
@@ -68,6 +68,9 @@ export default {
     label: '',
     color: 'primary',
   },
+  parameters: {
+    chromatic: { pauseAnimationAtEnd: true },
+  },
 } as Meta
 
 const Template: Story = (args: Args, storyContext) => ({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### ❓ Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] 📦 New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Spinner loader snapshot are always updated due to the animation, add option to pause it.

### 📝 Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes
- [ ] The component exists on old Prestashop UIKit and my pull request on [migrating documentation](https://github.com/PrestaShopCorp/devdocs.uikit.prestashop.com) is accepted.
