### PR TITLE
[Feature]: add menu open state to slot props

### DIFF
--- a/packages/components/menu/src/menu.vue
+++ b/packages/components/menu/src/menu.vue
@@ -1,11 +1,12 @@
 <template>
   <Popover
+    v-slot="{ open }"
     class="puik-menu"
     :class="[`puik-menu--position-${position}`, `puik-menu--align-${align}`]"
     as="div"
   >
     <PopoverButton class="puik-menu__trigger" as="template">
-      <slot name="trigger"></slot>
+      <slot name="trigger" :open="open"></slot>
     </PopoverButton>
 
     <transition
@@ -21,7 +22,7 @@
         class="puik-menu__content"
         :style="{ maxHeight, width }"
       >
-        <slot :close="close"></slot>
+        <slot :close="close" :open="open"></slot>
       </PopoverPanel>
     </transition>
   </Popover>

--- a/packages/components/menu/stories/menu.stories.ts
+++ b/packages/components/menu/stories/menu.stories.ts
@@ -61,10 +61,31 @@ export default {
     trigger: {
       control: 'none',
       description: 'Trigger used to show or hide menu',
+      table: {
+        type: {
+          summary: 'SlotProps',
+          detail: `
+  {
+    open: boolean
+  }
+          `,
+        },
+      },
     },
     default: {
       control: 'none',
       description: 'Menu content',
+      table: {
+        type: {
+          summary: 'SlotProps',
+          detail: `
+  {
+    open: boolean,
+    close: () => void
+  }
+            `,
+        },
+      },
     },
   },
   args: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### ❓ Types of changes

Adding open state of the menu to slop props

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] 📦 New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📝 Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes
- [ ] The component exists on old Prestashop UIKit and my pull request on [migrating documentation](https://github.com/PrestaShopCorp/devdocs.uikit.prestashop.com) is accepted.
