### PR TITLE
fix: (issue #159) sidebar-item active state (fix scss class)

### DIFF
--- a/packages/theme/src/sidebar-item.scss
+++ b/packages/theme/src/sidebar-item.scss
@@ -9,6 +9,9 @@
       @apply text-blue-700 font-bold;
     }
   }
+  &--active.puik-button--text {
+    @apply text-blue-700 font-bold bg-primary-200;
+  }
 
   &__button {
     @apply px-2 py-4 sm:py-2 justify-start font-normal text-left;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

fix scss file for displaying active state of sidebar item component

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] 📦 New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

fix puik-sidebar-item--active scss class

### 📝 Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes
- [ ] The component exists on old Prestashop UIKit and my pull request on [migrating documentation](https://github.com/PrestaShopCorp/devdocs.uikit.prestashop.com) is accepted.
