### PR TITLE
improvement: fix #186 [accordion] add props for paddings

### DIFF
--- a/packages/components/accordion/src/accordion.ts
+++ b/packages/components/accordion/src/accordion.ts
@@ -1,6 +1,16 @@
 import { buildProps } from '@puik/utils'
-import type { ExtractPropTypes } from 'vue'
+import type { ExtractPropTypes, PropType } from 'vue'
 import type accordion from './accordion.vue'
+
+export const paddingVariants = [
+  'smaller',
+  'small',
+  'normal',
+  'large',
+  'larger',
+] as const
+
+export type PuikPaddingVariant = (typeof paddingVariants)[number]
 
 export const accordionProps = buildProps({
   name: {
@@ -26,6 +36,26 @@ export const accordionProps = buildProps({
     type: Boolean,
     required: false,
     default: false,
+  },
+  headerPaddingX: {
+    type: String as PropType<PuikPaddingVariant>,
+    required: false,
+    default: 'large',
+  },
+  headerPaddingY: {
+    type: String as PropType<PuikPaddingVariant>,
+    required: false,
+    default: 'normal',
+  },
+  contentPaddingX: {
+    type: String as PropType<PuikPaddingVariant>,
+    required: false,
+    default: 'large',
+  },
+  contentPaddingY: {
+    type: String as PropType<PuikPaddingVariant>,
+    required: false,
+    default: 'normal',
   },
 } as const)
 

--- a/packages/components/accordion/src/accordion.vue
+++ b/packages/components/accordion/src/accordion.vue
@@ -1,15 +1,21 @@
 <template>
   <div
-    class="puik-accordion"
-    :class="{
-      'puik-accordion--expanded': isExpanded,
-      'puik-accordion--disabled': disabled,
-    }"
+    :class="[
+      'puik-accordion',
+      {
+        'puik-accordion--expanded': isExpanded,
+        'puik-accordion--disabled': disabled,
+      },
+    ]"
   >
     <button
       :aria-expanded="isExpanded"
       :aria-controls="id"
-      class="puik-accordion__header"
+      :class="[
+        `puik-accordion__header 
+        puik-accordion__header--padding-x-${headerPaddingX}
+        puik-accordion__header--padding-y-${headerPaddingY}`,
+      ]"
       :disabled="disabled"
       @click="onClick"
     >
@@ -32,7 +38,15 @@
       ></puik-icon>
     </button>
 
-    <div v-show="isExpanded" :id="id" class="puik-accordion__content">
+    <div
+      v-show="isExpanded"
+      :id="id"
+      :class="[
+        `puik-accordion__content 
+        puik-accordion__content--padding-x-${contentPaddingX}
+        puik-accordion__content--padding-y-${contentPaddingY}`,
+      ]"
+    >
       <slot></slot>
     </div>
   </div>

--- a/packages/components/accordion/stories/accordion.stories.ts
+++ b/packages/components/accordion/stories/accordion.stories.ts
@@ -1,6 +1,9 @@
 import PuikAccordionGroup from '../src/accordion-group.vue'
 import PuikAccordion from '../src/accordion.vue'
+import { paddingVariants } from '../src/accordion'
 import type { Meta, StoryFn, Args } from '@storybook/vue3'
+
+const paddingVariantsSummary = paddingVariants.join(' ')
 
 export default {
   title: 'Components/Accordion/Accordion',
@@ -29,6 +32,70 @@ export default {
       table: {
         defaultValue: {
           summary: false,
+        },
+      },
+    },
+    headerPaddingX: {
+      control: 'select',
+      options: ['smaller', 'small', 'normal', 'large', 'larger'],
+      description: 'Set horizontal paddings of accordion header',
+      table: {
+        defaultValue: {
+          summary: 'large',
+          detail: 'large (24px)',
+        },
+        type: {
+          summary: paddingVariantsSummary,
+          detail:
+            'smaller(4px) | small(8px) | normal(16px)| large(24px) | larger(32px)',
+        },
+      },
+    },
+    headerPaddingY: {
+      control: 'select',
+      options: ['smaller', 'small', 'normal', 'large', 'larger'],
+      description: 'Set vertical paddings of accordion header',
+      table: {
+        defaultValue: {
+          summary: 'normal',
+          detail: 'normal(16px)',
+        },
+        type: {
+          summary: paddingVariantsSummary,
+          detail:
+            'smaller(4px) | small(8px) | normal(16px)| large(24px) | larger(32px)',
+        },
+      },
+    },
+    contentPaddingX: {
+      control: 'select',
+      options: ['smaller', 'small', 'normal', 'large', 'larger'],
+      description: 'Set horizontal paddings of accordion content',
+      table: {
+        defaultValue: {
+          summary: 'large',
+          detail: 'large (24px)',
+        },
+        type: {
+          summary: paddingVariantsSummary,
+          detail:
+            'smaller(4px) | small(8px) | normal(16px)| large(24px) | larger(32px)',
+        },
+      },
+    },
+    contentPaddingY: {
+      control: 'select',
+      options: ['smaller', 'small', 'normal', 'large', 'larger'],
+      description: 'Set vertical paddings of accordion content',
+      table: {
+        defaultValue: {
+          summary: 'normal',
+          detail: 'normal(16px)',
+        },
+        type: {
+          summary: paddingVariantsSummary,
+          detail:
+            'smaller(4px) | small(8px) | normal(16px)| large(24px) | larger(32px)',
         },
       },
     },
@@ -80,6 +147,10 @@ export const Default = {
         :sub-title="subTitle"
         :icon="icon"
         :disabled="true|false"
+        header-padding-x="smaller | small | normal | large | larger"
+        header-padding-y="smaller | small | normal | large | larger"
+        content-padding-x="smaller | small | normal | large | larger"
+        content-padding-y="smaller | small | normal | large | larger"
     >
       Content 1
     </puik-accordion>
@@ -91,17 +162,32 @@ export const Default = {
       State classes
       Disabled: "puik-accordion--disabled"
       Expanded: "puik-accordion--expanded"
+
+      Padding Variants
+      $paddingVariants: smaller|small|normal|large|larger
     -->
     <div class="puik-accordion puik-accordion--expanded">
-      <button aria-expanded="true" aria-controls="accordion-id" class="puik-accordion__header">
+      <button aria-expanded="true" aria-controls="accordion-id" class="
+        puik-accordion__header
+        puik-accordion__header--padding-x-{$paddingVariants}
+        puik-accordion__header--padding-y-{$paddingVariants}"
+      >
         <div class="puik-icon material-icons-round puik-accordion__header__icon" style="font-size: 24px;">home</div>
         <div class="puik-accordion__header__content">
           <div class="puik-accordion__header__content__title">Accordion title</div>
           <div class="puik-accordion__header__content__sub-title">Accordion subtitle</div>
         </div>
-        <div class="puik-icon material-icons-round puik-accordion__header__expand__icon" style="font-size: 24px;">keyboard_arrow_up</div>
+        <div class="puik-icon material-icons-round puik-accordion__header__expand__icon" style="font-size: 24px;">
+          keyboard_arrow_up
+        </div>
       </button>
-      <div id="accordion-id" class="puik-accordion__content"> Content 1 </div>
+      <div id="accordion-id" class="
+        puik-accordion__content
+        puik-accordion__content--padding-x-{$paddingVariants}
+        puik-accordion__content--padding-y-{$paddingVariants}"
+      >
+        Content 1
+      </div>
     </div>
   </div>
         `,

--- a/packages/components/accordion/test/accordion.spec.ts
+++ b/packages/components/accordion/test/accordion.spec.ts
@@ -152,4 +152,44 @@ describe('Accordion tests', () => {
 
     expect(getAccordionIcon(wrapper).text()).toBe(icon)
   })
+
+  it('should setting small horizontal padding for accordion header', () => {
+    const headerPaddingX = 'small'
+    const template = `
+      <puik-accordion-group>
+        <puik-accordion
+          name="accordion-1"
+          icon="home"
+          header-padding-x=${headerPaddingX}
+        >
+          Content
+        </puik-accordion>
+      </puik-accordion-group>
+    `
+    factory(template)
+    const accordion = getAccordion(wrapper)
+    expect(getAccordionHeader(accordion).classes()).toContain(
+      `puik-accordion__header--padding-x-${headerPaddingX}`
+    )
+  })
+
+  it('should setting large vertical padding for accordion content', () => {
+    const headerPaddingY = 'large'
+    const template = `
+      <puik-accordion-group>
+        <puik-accordion
+          name="accordion-1"
+          icon="home"
+          content-padding-y=${headerPaddingY}
+        >
+          Content
+        </puik-accordion>
+      </puik-accordion-group>
+    `
+    factory(template)
+    const accordion = getAccordion(wrapper)
+    expect(getAccordionContent(accordion).classes()).toContain(
+      `puik-accordion__content--padding-y-${headerPaddingY}`
+    )
+  })
 })

--- a/packages/theme/src/accordion.scss
+++ b/packages/theme/src/accordion.scss
@@ -4,7 +4,7 @@
   @apply border border-primary-400 mb-4;
 
   &__header {
-    @apply px-6 py-4 flex w-full items-center;
+    @apply flex w-full items-center;
 
     &:hover {
       @apply bg-primary-200;
@@ -32,10 +32,78 @@
     &__expand__icon {
       @apply ml-auto text-primary-600 transform transition-transform duration-100 ease-in-out;
     }
+    &--padding-x {
+      &-smaller {
+        @apply px-1;
+      }
+      &-small {
+        @apply px-2;
+      }
+      &-normal {
+        @apply px-4;
+      }
+      &-large {
+        @apply px-6;
+      }
+      &-larger {
+        @apply px-8;
+      }
+    }
+    &--padding-y {
+      &-smaller {
+        @apply py-1;
+      }
+      &-small {
+        @apply py-2;
+      }
+      &-normal {
+        @apply py-4;
+      }
+      &-large {
+        @apply py-6;
+      }
+      &-larger {
+        @apply py-8;
+      }
+    }
   }
   &__content {
     @extend .puik-body-default;
-    @apply p-4 ml-4 text-primary-600 invisible;
+    @apply text-primary-600 invisible;
+    &--padding-x {
+      &-smaller {
+        @apply px-1;
+      }
+      &-small {
+        @apply px-2;
+      }
+      &-normal {
+        @apply px-4;
+      }
+      &-large {
+        @apply px-6;
+      }
+      &-larger {
+        @apply px-8;
+      }
+    }
+    &--padding-y {
+      &-smaller {
+        @apply py-1;
+      }
+      &-small {
+        @apply py-2;
+      }
+      &-normal {
+        @apply py-4;
+      }
+      &-large {
+        @apply py-6;
+      }
+      &-larger {
+        @apply py-8;
+      }
+    }
   }
   &--expanded {
     .puik-accordion__title {


### PR DESCRIPTION
possibility for the user to modify the header and content paddings

### ❓ Types of changes

New Props : 

 - headerPaddingX
 - headerPaddingY
 - contentPaddingX
 - contentPaddingY
 
available values for props above: 

- "smaller" (4px)
- "small" (8px)
- "normal" (16px) => default value for vertical paddings
- "large" (24px), => default value for horizontal paddings
- "larger" (32px)

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [x] 📦 New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📝 Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes
- [ ] The component exists on old Prestashop UIKit and my pull request on [migrating documentation](https://github.com/PrestaShopCorp/devdocs.uikit.prestashop.com) is accepted.
