### PR TITLE
fix: #232 : puik-link underline on multi-lines

### DIFF
--- a/packages/components/link/src/link.ts
+++ b/packages/components/link/src/link.ts
@@ -3,16 +3,33 @@ import type { RouteLocationRaw } from 'vue-router'
 import type { ExtractPropTypes, PropType } from 'vue'
 import type Link from './link.vue'
 
+export enum PuikLinkTarget {
+  BLANK = '_blank',
+  SELF = '_self',
+  PARENT = '_parent',
+  TOP = '_top',
+}
+
 export const targetVariants = ['_blank', '_self', '_parent', '_top'] as const
-export type PuikTargetVariant = (typeof targetVariants)[number]
+export type PuikTargetString = (typeof targetVariants)[number]
+
+export enum PuikLinkSize {
+  SMALL = 'sm',
+  MEDIUM = 'md',
+  LARGE = 'lg',
+}
+
 export const linkSizes = ['sm', 'md', 'lg'] as const
-export type PuikLinkSize = (typeof linkSizes)[number]
+export type PuikLinkSizeString = (typeof linkSizes)[number]
 
 export const linkProps = buildProps({
   size: {
-    type: String as PropType<PuikLinkSize>,
+    type: [
+      String as PropType<PuikLinkSize>,
+      String as PropType<PuikLinkSizeString>,
+    ],
     required: false,
-    default: 'md',
+    default: PuikLinkSize.MEDIUM,
   },
   href: {
     type: String,
@@ -25,9 +42,12 @@ export const linkProps = buildProps({
     default: undefined,
   },
   target: {
-    type: String as PropType<PuikTargetVariant>,
+    type: [
+      String as PropType<PuikLinkTarget>,
+      String as PropType<PuikTargetString>,
+    ],
     required: false,
-    default: '_self',
+    default: PuikLinkTarget.SELF,
   },
   title: {
     type: String,

--- a/packages/components/link/src/link.vue
+++ b/packages/components/link/src/link.vue
@@ -7,17 +7,26 @@
     :class="['puik-link', `puik-link--${size}`]"
   >
     <slot></slot>
+
+    <span
+      v-if="props.target === PuikLinkTarget.BLANK"
+      class="puik-link__target__icon"
+    >
+      {{ TARGET_BLANK_ICON }}
+    </span>
   </component>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { linkProps } from './link'
+import { linkProps, PuikLinkTarget } from './link'
+
 defineOptions({
   name: 'PuikLink',
 })
 
 const props = defineProps(linkProps)
+const TARGET_BLANK_ICON = 'open_in_new'
 
 const componentType = computed(() => {
   if (props.to) {

--- a/packages/theme/src/link.scss
+++ b/packages/theme/src/link.scss
@@ -1,21 +1,10 @@
 @use './common/typography.scss';
 
 .puik-link {
-  @apply relative text-primary transition m-0.5 p-0.5 py-[4px];
-  &:before {
-    content: '';
-    @apply absolute h-[1px] bg-primary-500 bottom-[4px] left-[50%] translate-x-[-50%] transition-all ease-in-out duration-150;
-    width: calc(100% - 4px);
-  }
+  @apply relative py-[1px] text-primary bg-gradient-to-bl from-primary-500 from-primary-500 bg-no-repeat bg-[length:100%_1px] bg-left-bottom transition-all ease-in-out duration-150;
   &:hover,
   &:active {
-    @apply cursor-pointer;
-    &:before {
-      @apply bg-primary-800 bottom-[2.5px] transition-all ease-in-out duration-150;
-    }
-    &:before:visited {
-      @apply bg-primary-800;
-    }
+    @apply py-[2.5px] cursor-pointer from-primary-800 to-primary-800 transition-all ease-in-out duration-150;
   }
   &:focus-visible {
     @apply outline-none ring-2 ring-blue rounded-[4px] shadow-none;

--- a/packages/theme/src/link.scss
+++ b/packages/theme/src/link.scss
@@ -2,11 +2,11 @@
 
 .puik-link {
   @apply relative py-[0.5px] text-primary bg-gradient-to-bl from-primary-500 to-primary-500 bg-no-repeat bg-[length:100%_1px] transition-all ease-in-out duration-150;
-  background-position: left bottom 0px;
+  background-position: left bottom 1.25px;
   &:hover,
   &:active {
     @apply cursor-pointer from-primary-800 to-primary-800 transition-all ease-in-out duration-150;
-    background-position: left bottom 1.25px;
+    background-position: left bottom 0px;
   }
   &:focus-visible {
     @apply outline-none ring-2 ring-blue rounded-[4px] shadow-none;

--- a/packages/theme/src/link.scss
+++ b/packages/theme/src/link.scss
@@ -1,12 +1,10 @@
 @use './common/typography.scss';
 
 .puik-link {
-  @apply relative py-[0.5px] text-primary bg-gradient-to-bl from-primary-500 to-primary-500 bg-no-repeat bg-[length:100%_1px] transition-all ease-in-out duration-150;
-  background-position: left bottom 1.25px;
+  @apply relative py-[0.5px] text-primary bg-gradient-to-bl from-primary-500 to-primary-500 bg-no-repeat bg-[length:100%_1px] bg-[left_bottom_1.25px] transition-all ease-in-out duration-150;
   &:hover,
   &:active {
-    @apply cursor-pointer from-primary-800 to-primary-800 transition-all ease-in-out duration-150;
-    background-position: left bottom 0px;
+    @apply cursor-pointer from-primary-800 to-primary-800 bg-left-bottom transition-all ease-in-out duration-150;
   }
   &:focus-visible {
     @apply outline-none ring-2 ring-blue rounded-[4px] shadow-none;

--- a/packages/theme/src/link.scss
+++ b/packages/theme/src/link.scss
@@ -1,29 +1,47 @@
 @use './common/typography.scss';
 
 .puik-link {
-  @apply relative py-[0.5px] text-primary bg-gradient-to-bl from-primary-500 to-primary-500 bg-no-repeat bg-[length:100%_1px] bg-[left_bottom_1.25px] transition-all ease-in-out duration-150;
+  @apply cursor-pointer 
+    relative 
+    text-primary
+    
+    underline 
+    decoration-auto
+    underline-offset-[2px]
+    decoration-primary-500
+    
+    transition-all
+    duration-150;
+
   &:hover,
   &:active {
-    @apply cursor-pointer from-primary-800 to-primary-800 bg-left-bottom transition-all ease-in-out duration-150;
+    @apply decoration-primary underline-offset-[5px];
   }
+
   &:focus-visible {
     @apply outline-none ring-2 ring-blue rounded-[4px] shadow-none;
   }
+
   &:visited {
     @apply text-purple-700;
   }
-  &[target='_blank'] {
-    &:after {
-      content: 'open_in_new';
-      @apply font-materialIcons ml-1.5 inline-block align-middle leading-[1em];
+
+  &__target__icon {
+    @apply font-materialIcons align-bottom;
+
+    &:before {
+      @apply content-['_'] text-[0.35rem] leading-[0.25rem];
     }
   }
+
   &--sm {
     @extend .puik-body-small;
   }
+
   &--md {
     @extend .puik-body-default;
   }
+
   &--lg {
     @extend .puik-body-large;
   }

--- a/packages/theme/src/link.scss
+++ b/packages/theme/src/link.scss
@@ -1,7 +1,7 @@
 @use './common/typography.scss';
 
 .puik-link {
-  @apply relative py-[1px] text-primary bg-gradient-to-bl from-primary-500 from-primary-500 bg-no-repeat bg-[length:100%_1px] bg-left-bottom transition-all ease-in-out duration-150;
+  @apply relative py-[1px] text-primary bg-gradient-to-bl from-primary-500 to-primary-500 bg-no-repeat bg-[length:100%_1px] bg-left-bottom transition-all ease-in-out duration-150;
   &:hover,
   &:active {
     @apply py-[2.5px] cursor-pointer from-primary-800 to-primary-800 transition-all ease-in-out duration-150;

--- a/packages/theme/src/link.scss
+++ b/packages/theme/src/link.scss
@@ -1,10 +1,12 @@
 @use './common/typography.scss';
 
 .puik-link {
-  @apply relative py-[1px] text-primary bg-gradient-to-bl from-primary-500 to-primary-500 bg-no-repeat bg-[length:100%_1px] bg-left-bottom transition-all ease-in-out duration-150;
+  @apply relative py-[0.5px] text-primary bg-gradient-to-bl from-primary-500 to-primary-500 bg-no-repeat bg-[length:100%_1px] transition-all ease-in-out duration-150;
+  background-position: left bottom 0px;
   &:hover,
   &:active {
-    @apply py-[2.5px] cursor-pointer from-primary-800 to-primary-800 transition-all ease-in-out duration-150;
+    @apply cursor-pointer from-primary-800 to-primary-800 transition-all ease-in-out duration-150;
+    background-position: left bottom 1.25px;
   }
   &:focus-visible {
     @apply outline-none ring-2 ring-blue rounded-[4px] shadow-none;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### ❓ Types of changes
fix : [BUG] puik link decoration underline is fucked up on multi-line 😭 + width 100% not good #232

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] 📦 New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there any PR to sync with ? -->
<!--- The component exists on old Prestashop UIKit ? Please create pull request on [migrating documentation](https://github.com/PrestaShopCorp/devdocs.uikit.prestashop.com) to help for migration.  -->

### 📝 Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes
- [ ] The component exists on old Prestashop UIKit and my pull request on [migrating documentation](https://github.com/PrestaShopCorp/devdocs.uikit.prestashop.com) is accepted.
