### PR TITLE
feat: add icon to the left and right button in alert component

### DIFF
--- a/packages/components/alert/src/alert.ts
+++ b/packages/components/alert/src/alert.ts
@@ -37,6 +37,16 @@ export const alertProps = buildProps({
     required: false,
     default: undefined,
   },
+  buttonLeftIcon: {
+    type: String,
+    required: false,
+    default: '',
+  },
+  buttonRightIcon: {
+    type: String,
+    required: false,
+    default: '',
+  },
   isClosable: {
     type: Boolean,
     required: false,

--- a/packages/components/alert/src/alert.vue
+++ b/packages/components/alert/src/alert.vue
@@ -32,6 +32,8 @@
         v-if="buttonLabel"
         :variant="variant"
         class="puik-alert__button"
+        :right-icon="buttonRightIcon"
+        :left-icon="buttonLeftIcon"
         :data-test="dataTest != undefined ? `button-${dataTest}` : undefined"
         @click="click"
       >

--- a/packages/components/alert/stories/alert.stories.ts
+++ b/packages/components/alert/stories/alert.stories.ts
@@ -40,6 +40,14 @@ export default {
     buttonLabel: {
       description: 'Label of the button',
     },
+    buttonLeftIcon: {
+      description: 'Icon to the left button',
+      control: 'text',
+    },
+    buttonRightIcon: {
+      description: 'Icon to the right button',
+      control: 'text',
+    },
     isClosable: {
       description: 'Display a close button',
     },
@@ -310,7 +318,85 @@ export const Danger: StoryObj = {
         <span class="puik-alert__description">This a danger alert with a title and a description.</span>
       </div>
     </div>
-    <button class="puik-alert__button">Button</button>
+    <button class="puik-button puik-button--success puik-button--md puik-alert__button">
+      <div class="puik-icon puik-button__right-icon" style="font-size: 1.25rem;">
+        open_in_new
+      </div>
+      Button
+    </button>
+  </div>
+        `,
+        language: 'html',
+      },
+    },
+  },
+}
+
+export const WithIcon = {
+  render: () => ({
+    components: {
+      PuikAlert,
+    },
+    template: `
+      <div class="flex flex-col space-y-4">
+      <puik-alert title="Title" button-label="Button" button-right-icon="shopping_cart">This a success alert with a title, description and icon to the right of button.</puik-alert>
+      <puik-alert title="Title" button-label="Button" button-left-icon="shopping_cart">This a success alert with a title, description and icon to the left of button.</puik-alert>
+    </div>
+    `,
+  }),
+
+  parameters: {
+    docs: {
+      source: {
+        code: `
+  <!--VueJS Snippet-->
+  <puik-alert
+    title="Title"
+    button-label="Button"
+    button-left-icon="shopping_cart"
+    @click="click"
+  >
+  This a success alert with a title, description and icon to the right of button.
+  </puik-alert>
+  <puik-alert
+    title="Title"
+    button-label="Button"
+    button-left-icon="shopping_cart"
+    @click="click"
+  >
+  This a success alert with a title, description and icon to the right of button.
+  </puik-alert>
+
+  <!--HTML/CSS Snippet-->
+  <div class="puik-alert puik-alert--info puik-alert--no-borders" aria-live="polite">
+    <div class="puik-alert__content">
+      <span class="puik-icon puik-alert__icon">info</span>
+      <div class="puik-alert__text">
+        <p class="puik-alert__title">Title</p>
+        <span class="puik-alert__description">This a success alert with a title, description and icon to the ledt of button.</span>
+      </div>
+    </div>
+    <button class="puik-button puik-button--success puik-button--md puik-alert__button">
+      <div class="puik-icon puik-button__left-icon" style="font-size: 1.25rem;">
+        shopping_cart
+      </div>
+      Button
+    </button>
+  </div>
+  <div class="puik-alert puik-alert--info puik-alert--no-borders" aria-live="polite">
+    <div class="puik-alert__content">
+      <span class="puik-icon puik-alert__icon">info</span>
+      <div class="puik-alert__text">
+        <p class="puik-alert__title">Title</p>
+        <span class="puik-alert__description">This a success alert with a title, description and icon to the right of button.</span>
+      </div>
+    </div>
+    <button class="puik-button puik-button--success puik-button--md puik-alert__button">
+      <div class="puik-icon puik-button__right-icon" style="font-size: 1.25rem;">
+        shopping_cart
+      </div>
+      Button
+    </button>
   </div>
         `,
         language: 'html',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### ❓ Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] 📦 New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!--- Describe your changes in detail -->
I add two props to Alert component for put an icon on the left or right to the button
<!--- Why is this change required? What problem does it solve? -->
It's a request for Customer Platform
<!--- Is there any PR to sync with ? -->
<!--- The component exists on old Prestashop UIKit ? Please create pull request on [migrating documentation](https://github.com/PrestaShopCorp/devdocs.uikit.prestashop.com) to help for migration.  -->

### 📝 Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes
I didn't make a test because there are tests for the button component
- [ ] The component exists on old Prestashop UIKit and my pull request on [migrating documentation](https://github.com/PrestaShopCorp/devdocs.uikit.prestashop.com) is accepted.
