### PR TITLE
Feat - Add high contrast variant for PuikLink

### DIFF
--- a/packages/components/link/src/link.ts
+++ b/packages/components/link/src/link.ts
@@ -59,6 +59,11 @@ export const linkProps = buildProps({
     required: false,
     default: undefined,
   },
+  highContrast: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
 } as const)
 
 export type LinkProps = ExtractPropTypes<typeof linkProps>

--- a/packages/components/link/src/link.vue
+++ b/packages/components/link/src/link.vue
@@ -4,7 +4,11 @@
     v-bind="pathProp"
     :target="target"
     :title="title"
-    :class="['puik-link', `puik-link--${size}`]"
+    :class="[
+      'puik-link',
+      `puik-link--${size}`,
+      { 'puik-link--high-contrast': highContrast },
+    ]"
     :data-test="dataTest"
   >
     <slot></slot>

--- a/packages/components/link/stories/link.stories.ts
+++ b/packages/components/link/stories/link.stories.ts
@@ -45,6 +45,15 @@ export default {
         },
       },
     },
+    highContrast: {
+      description:
+        'Sets the link in high contrast mode by disabling the purple color for the visited stated',
+      table: {
+        defaultValue: {
+          summary: false,
+        },
+      },
+    },
     default: {
       control: 'text',
       description: 'Label of the link',
@@ -61,6 +70,7 @@ export default {
     href: '#',
     to: undefined,
     target: '_self',
+    highContrast: false,
     default: "I'm a cool link",
     title: "I'm a tooltip for your link",
     size: 'md',
@@ -99,8 +109,9 @@ export const Default = {
   <!--
   $sizes: ${linkSizesSummary}
   $targets: ${targetVariantsSummary}
+  $variants: high-contrast (optional)
   -->
-  <a class="puik-link puik-link--{$sizes}" href="#" target="$targets" title="I'm a tooltip for your link">
+  <a class="puik-link puik-link--{$sizes} puik-link--{$variants}" href="#" target="$targets" title="I'm a tooltip for your link">
     I'm a cool link
   </a>
         `,

--- a/packages/components/link/test/link.spec.ts
+++ b/packages/components/link/test/link.spec.ts
@@ -41,4 +41,9 @@ describe('Link tests', () => {
     factory({ href: '/test', 'data-test': 'test' })
     expect(findLink().attributes('data-test')).toBe('test')
   })
+
+  it('should set the link in high-contrast mode', () => {
+    factory({ highContrast: true })
+    expect(findLink().classes()).toContain('puik-link--high-contrast')
+  })
 })

--- a/packages/theme/src/link.scss
+++ b/packages/theme/src/link.scss
@@ -45,4 +45,11 @@
   &--lg {
     @extend .puik-body-large;
   }
+
+  &--high-contrast {
+    &:visited {
+      @apply text-primary;
+    }
+    @apply decoration-primary;
+  }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### ❓ Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] 📦 New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there any PR to sync with ? -->
<!--- The component exists on old Prestashop UIKit ? Please create pull request on [migrating documentation](https://github.com/PrestaShopCorp/devdocs.uikit.prestashop.com) to help for migration.  -->
Added a high contrast variant for the PuikLink (this variant disables the link purple when the link has been visited)

We need this feature to finish a task for this sprint


### 📝 Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes
- [ ] The component exists on old Prestashop UIKit and my pull request on [migrating documentation](https://github.com/PrestaShopCorp/devdocs.uikit.prestashop.com) is accepted.
