### PR TITLE
fix: #310 added the dataItems prop to use in the web-component version

### DIFF
--- a/packages/components/breadcrumb/src/breadcrumb.ts
+++ b/packages/components/breadcrumb/src/breadcrumb.ts
@@ -11,7 +11,8 @@ export interface BreadcrumbItem {
 }
 
 export interface BreadcrumbProps {
-  items: BreadcrumbItem[]
+  items?: BreadcrumbItem[]
+  dataItems?: string
   separatorIcon?: string
   icon?: string
 }

--- a/packages/components/breadcrumb/src/breadcrumb.ts
+++ b/packages/components/breadcrumb/src/breadcrumb.ts
@@ -12,7 +12,7 @@ export interface BreadcrumbItem {
 
 export interface BreadcrumbProps {
   items?: BreadcrumbItem[]
-  dataItems?: string
+  itemsJson?: string
   separatorIcon?: string
   icon?: string
 }

--- a/packages/components/breadcrumb/src/breadcrumb.vue
+++ b/packages/components/breadcrumb/src/breadcrumb.vue
@@ -1,6 +1,6 @@
 <template>
   <nav
-    v-if="internalItems?.length"
+    v-if="internalItems && internalItems.length"
     class="puik-breadcrumb"
     role="navigation"
   >
@@ -35,6 +35,7 @@
     </div>
 
     <div
+      v-if="internalItems.length"
       class="puik-breadcrumb__item--last"
       :data-test="
         internalItems[internalItems.length - 1].dataTest
@@ -63,10 +64,10 @@ const props = withDefaults(defineProps<BreadcrumbProps>(), {
 const internalItems = ref<BreadcrumbItem[]>([]);
 
 const itemsToWatch = computed(() => {
-  return props.dataItems ? JSON.parse(props.dataItems) : props.items;
+  return props.itemsJson ? JSON.parse(props.itemsJson) : props.items;
 });
 
-watch(itemsToWatch, (newValue: BreadcrumbItem[]) => {
+watch(itemsToWatch, (newValue) => {
   internalItems.value = newValue;
 }, { immediate: true });
 </script>

--- a/packages/components/breadcrumb/src/breadcrumb.vue
+++ b/packages/components/breadcrumb/src/breadcrumb.vue
@@ -1,6 +1,6 @@
 <template>
   <nav
-    v-if="items.length"
+    v-if="internalItems?.length"
     class="puik-breadcrumb"
     role="navigation"
   >
@@ -12,7 +12,7 @@
     />
 
     <div
-      v-for="(item, index) in items.slice(0, items.length - 1)"
+      v-for="(item, index) in internalItems.slice(0, internalItems.length - 1)"
       :key="`puik-breadcrumb-item-${index}`"
       class="puik-breadcrumb__item"
     >
@@ -37,12 +37,12 @@
     <div
       class="puik-breadcrumb__item--last"
       :data-test="
-        items[items.length - 1].dataTest
-          ? items[items.length - 1].dataTest
+        internalItems[internalItems.length - 1].dataTest
+          ? internalItems[internalItems.length - 1].dataTest
           : undefined
       "
     >
-      {{ items[items.length - 1].label }}
+      {{ internalItems[internalItems.length - 1].label }}
     </div>
   </nav>
 </template>
@@ -50,14 +50,25 @@
 <script setup lang="ts">
 import PuikLink from '../../link/src/link.vue';
 import PuikIcon from '../../icon/src/icon.vue';
-import type { BreadcrumbProps } from './breadcrumb';
+import { computed, ref, watch } from 'vue';
+import type { BreadcrumbProps, BreadcrumbItem } from './breadcrumb';
 defineOptions({
   name: 'PuikBreadcrumb'
 });
 
-withDefaults(defineProps<BreadcrumbProps>(), {
+const props = withDefaults(defineProps<BreadcrumbProps>(), {
   separatorIcon: 'keyboard_arrow_right'
 });
+
+const internalItems = ref<BreadcrumbItem[]>([]);
+
+const itemsToWatch = computed(() => {
+  return props.dataItems ? JSON.parse(props.dataItems) : props.items;
+});
+
+watch(itemsToWatch, (newValue: BreadcrumbItem[]) => {
+  internalItems.value = newValue;
+}, { immediate: true });
 </script>
 
 <style lang="scss">

--- a/packages/components/breadcrumb/stories/breadcrumb.stories.ts
+++ b/packages/components/breadcrumb/stories/breadcrumb.stories.ts
@@ -9,7 +9,7 @@ export default {
       description: 'Link displayed in breadcrumb',
       table: {
         defaultValue: {
-          summary: '[]'
+          summary: 'undefined'
         },
         type: {
           summary: 'BreadcrumbItem[]',
@@ -25,6 +25,19 @@ interface BreadBreadcrumbItem {
   target: '_blank' | '_self' | '_parent' | '_top' | undefined,
   dataTest: string | undefined,
 }`
+        }
+      }
+    },
+    dataItems: {
+      control: 'text',
+      description: 'The breadcrumb items as a JSON string. Use this prop when using the component as a Web Component. For regular Vue usage, prefer the `items` prop.',
+      table: {
+        defaultValue: {
+          summary: 'undefined'
+        },
+        type: {
+          summary: 'string',
+          detail: 'A JSON string representing an array of BreadcrumbItem'
         }
       }
     },
@@ -65,6 +78,21 @@ interface BreadBreadcrumbItem {
         target: '_blank'
       }
     ],
+    dataItems: JSON.stringify([
+      {
+        label: 'First link',
+        href: '#'
+      },
+      {
+        label: 'Second link',
+        href: '#'
+      },
+      {
+        label: 'Third link',
+        to: 'name',
+        target: '_blank'
+      }
+    ]),
     separatorIcon: 'keyboard_arrow_right',
     icon: 'home'
   }
@@ -89,8 +117,92 @@ export const Default = {
       source: {
         code: `
   <!--VueJS Snippet-->
+  const items = [
+    {
+      label: 'First link',
+      href: '#'
+    },
+    {
+      label: 'Second link',
+      href: '#'
+    },
+    {
+      label: 'Third link',
+      to: 'name',
+      target: '_blank'
+    }
+  ]
+
   <puik-breadcrumb
     :items="items"
+    :icon="icon"
+  ></puik-breadcrumb>
+
+  <!--HTML/CSS Snippet-->
+  <nav class="puik-breadcrumb" role="navigation">
+    <div class="puik-icon material-icons-round puik-breadcrumb__home-icon" style="font-size: 16px;">home</div>
+    <div class="puik-breadcrumb__item">
+      <a href="#" target="_self" class="puik-link puik-link--sm puik-breadcrumb__item-link">First link</a>
+      <div class="puik-icon material-icons-round puik-breadcrumb__item-icon" style="font-size: 16px;">keyboard_arrow_right</div>
+    </div>
+    <div class="puik-breadcrumb__item">
+      <a href="#" target="_self" class="puik-link puik-link--sm puik-breadcrumb__item-link">Second link</a>
+      <div class="puik-icon material-icons-round puik-breadcrumb__item-icon" style="font-size: 16px;">keyboard_arrow_right</div>
+    </div>
+    <div class="puik-breadcrumb__item--last">Third link</div>
+  </nav>
+        `,
+        language: 'html'
+      }
+    }
+  }
+};
+
+export const WithDataItems = {
+  render: Template,
+  args: {
+    dataItems: JSON.stringify([
+      {
+        label: 'First link',
+        href: '#'
+      },
+      {
+        label: 'Second link',
+        href: '#'
+      },
+      {
+        label: 'Third link',
+        to: 'name',
+        target: '_blank'
+      }
+    ]),
+    separatorIcon: 'keyboard_arrow_right',
+    icon: 'home'
+  },
+
+  parameters: {
+    docs: {
+      source: {
+        code: `
+  <!--VueJS Snippet-->
+  dataItems: JSON.stringify([
+    {
+      label: 'First link',
+      href: '#'
+    },
+    {
+      label: 'Second link',
+      href: '#'
+    },
+    {
+      label: 'Third link',
+      to: 'name',
+      target: '_blank'
+    }
+  ])
+
+  <puik-breadcrumb
+    :data-items="dataItems"
     :icon="icon"
   ></puik-breadcrumb>
 

--- a/packages/components/breadcrumb/stories/breadcrumb.stories.ts
+++ b/packages/components/breadcrumb/stories/breadcrumb.stories.ts
@@ -28,7 +28,7 @@ interface BreadBreadcrumbItem {
         }
       }
     },
-    dataItems: {
+    itemsJson: {
       control: 'text',
       description: 'The breadcrumb items as a JSON string. Use this prop when using the component as a Web Component. For regular Vue usage, prefer the `items` prop.',
       table: {
@@ -78,7 +78,7 @@ interface BreadBreadcrumbItem {
         target: '_blank'
       }
     ],
-    dataItems: JSON.stringify([
+    itemsJson: JSON.stringify([
       {
         label: 'First link',
         href: '#'
@@ -161,7 +161,7 @@ export const Default = {
 export const WithDataItems = {
   render: Template,
   args: {
-    dataItems: JSON.stringify([
+    itemsJson: JSON.stringify([
       {
         label: 'First link',
         href: '#'
@@ -185,7 +185,7 @@ export const WithDataItems = {
       source: {
         code: `
   <!--VueJS Snippet-->
-  dataItems: JSON.stringify([
+  itemsJson: JSON.stringify([
     {
       label: 'First link',
       href: '#'
@@ -202,7 +202,7 @@ export const WithDataItems = {
   ])
 
   <puik-breadcrumb
-    :data-items="dataItems"
+    :items-json="itemsJson"
     :icon="icon"
   ></puik-breadcrumb>
 

--- a/packages/components/breadcrumb/test/breadcrumb.spec.ts
+++ b/packages/components/breadcrumb/test/breadcrumb.spec.ts
@@ -41,6 +41,8 @@ describe('Breadcrumb tests', () => {
       label: 'Last link'
     }
   ];
+  const itemsJson: string = JSON.stringify(items);
+
   it('should be a vue instance', () => {
     factory({ items });
     expect(wrapper).toBeTruthy();
@@ -95,5 +97,13 @@ describe('Breadcrumb tests', () => {
     factory({ items });
     const lastItem = getBreadcrumbItems().pop();
     expect(lastItem?.element.tagName).toBe('DIV');
+  });
+  it('should handle dataItems prop correctly', () => {
+    factory({ dataItems: itemsJson });
+    const localItems = getBreadcrumbItems();
+    expect(localItems.length).toBe(items.length);
+    items.forEach((item, index) => {
+      expect(localItems[index].text()).toContain(item.label);
+    });
   });
 });

--- a/packages/components/breadcrumb/test/breadcrumb.spec.ts
+++ b/packages/components/breadcrumb/test/breadcrumb.spec.ts
@@ -99,7 +99,7 @@ describe('Breadcrumb tests', () => {
     expect(lastItem?.element.tagName).toBe('DIV');
   });
   it('should handle dataItems prop correctly', () => {
-    factory({ dataItems: itemsJson });
+    factory({ itemsJson });
     const localItems = getBreadcrumbItems();
     expect(localItems.length).toBe(items.length);
     items.forEach((item, index) => {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above -->

### ❓ Types of changes
added the dataItems prop to use in the web-component version
(stingify version of items)

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] 📦 New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there any PR to sync with ? -->
<!--- The component exists on old Prestashop UIKit ? Please create pull request on [migrating documentation](https://github.com/PrestaShopCorp/devdocs.uikit.prestashop.com) to help for migration.  -->

### 📝 Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes
- [ ] The component exists on old Prestashop UIKit and my pull request on [migrating documentation](https://github.com/PrestaShopCorp/devdocs.uikit.prestashop.com) is accepted.
