### PR TITLE
docs: disable-border props alert in stories + id not required for tag

### DIFF
--- a/packages/components/alert/stories/alert.stories.ts
+++ b/packages/components/alert/stories/alert.stories.ts
@@ -309,7 +309,7 @@ export const Warning: StoryObj = {
   <puik-alert
     title="Title"
     variant="warning"
-    :disabled-borders="true|false"
+    :disable-borders="true|false"
     button-label="Button"
     @click="click"
   >
@@ -358,7 +358,7 @@ export const Info: StoryObj = {
   <puik-alert
     title="Title"
     variant="info"
-    :disabled-borders="true|false"
+    :disable-borders="true|false"
     button-label="Button"
     @click="click"
   >
@@ -407,7 +407,7 @@ export const Danger: StoryObj = {
   <puik-alert
     title="Title"
     variant="danger"
-    :disabled-borders="true|false"
+    :disable-borders="true|false"
     button-label="Button"
     @click="click"
   >

--- a/packages/components/tag/src/tag.ts
+++ b/packages/components/tag/src/tag.ts
@@ -19,7 +19,7 @@ export type PuikTagSizeVariant = (typeof tagSizeVariants)[number]
 export const tagProps = buildProps({
   id: {
     type: String,
-    required: true,
+    required: false,
     default: undefined,
   },
   content: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### ❓ Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] 📦 New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- Required id in tag: Don't need to set it to make the component works, so don't put it as required
- disabled-border: Fix documentation, props name is disable-border

### 📝 Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes
- [ ] The component exists on old Prestashop UIKit and my pull request on [migrating documentation](https://github.com/PrestaShopCorp/devdocs.uikit.prestashop.com) is accepted.
