### PR TITLE
chore: versions bumped

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @prestashopcorp/puik-docs
 
+## 1.1.1
+
+### Patch Changes
+
+- update documentations (storybook and readme's), patch link component (style defaut link for visited state)
+
 ## 1.1.0
 
 ### Minor Changes

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@prestashopcorp/puik-docs",
   "description": "PUIK docs - Storybook documentation.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "main": "index.js",
   "license": "MIT",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @prestashopcorp/puik-components
 
+## 2.0.1
+
+### Patch Changes
+
+- update documentations (storybook and readme's), patch link component (style defaut link for visited state)
+- Updated dependencies
+  - @prestashopcorp/puik-theme@2.0.1
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@prestashopcorp/puik-components",
   "description": "PUIK Vue 3 components library.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "scripts": {
     "build": "vue-tsc --noEmit --project ./tsconfig.build.json && vite build"

--- a/packages/puik/CHANGELOG.md
+++ b/packages/puik/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @prestashopcorp/puik
 
+## 2.0.1
+
+### Patch Changes
+
+- update documentations (storybook and readme's), patch link component (style defaut link for visited state)
+- Updated dependencies
+  - @prestashopcorp/puik-tailwind-preset@2.0.1
+  - @prestashopcorp/puik-web-components@2.0.1
+  - @prestashopcorp/puik-components@2.0.1
+  - @prestashopcorp/puik-resolver@2.0.1
+  - @prestashopcorp/puik-theme@2.0.1
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/puik/package.json
+++ b/packages/puik/package.json
@@ -3,7 +3,7 @@
   "description": "PUIK - This includes all public packages of PrestaShop UI kit.",
   "license": "MIT",
   "author": "Prestashop",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "scripts": {
     "build": "vue-tsc --noEmit --project ./tsconfig.build.json && vite build"

--- a/packages/resolver/CHANGELOG.md
+++ b/packages/resolver/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @prestashopcorp/puik-resolver
 
+## 2.0.1
+
+### Patch Changes
+
+- update documentations (storybook and readme's), patch link component (style defaut link for visited state)
+- Updated dependencies
+  - @prestashopcorp/puik-components@2.0.1
+  - @prestashopcorp/puik-theme@2.0.1
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@prestashopcorp/puik-resolver",
   "description": "PUIK resolver - For unplugin-vue-components.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "files": [
     "dist"

--- a/packages/tailwind-preset/CHANGELOG.md
+++ b/packages/tailwind-preset/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @prestashopcorp/puik-tailwind-preset
 
+## 2.0.1
+
+### Patch Changes
+
+- update documentations (storybook and readme's), patch link component (style defaut link for visited state)
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/tailwind-preset/package.json
+++ b/packages/tailwind-preset/package.json
@@ -2,7 +2,7 @@
   "name": "@prestashopcorp/puik-tailwind-preset",
   "description": "PUIK tailwind preset - A set of Tailwind CSS utility classes, adapted to the new branding.",
   "type": "module",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "files": [
     "dist"

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @prestashopcorp/puik-theme
 
+## 2.0.1
+
+### Patch Changes
+
+- update documentations (storybook and readme's), patch link component (style defaut link for visited state)
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@prestashopcorp/puik-theme",
   "description": "PUIK theme - CSS classes of Prestashop UI Kit.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "style": "./dist/index.css",
   "unpkg": "./dist/index.css",
   "jsdelivr": "./dist/index.css",

--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @prestashopcorp/puik-web-components
 
+## 2.0.1
+
+### Patch Changes
+
+- update documentations (storybook and readme's), patch link component (style defaut link for visited state)
+- Updated dependencies
+  - @prestashopcorp/puik-components@2.0.1
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@prestashopcorp/puik-web-components",
   "description": "PUIK Web-Components library.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit --project ./tsconfig.build.json && vite build"


### PR DESCRIPTION
## Bump versions with changeset

prestashopcorp/puik-components` 2.0.0 -> 2.0.1`
prestashopcorp/puik-web-components `2.0.0 -> 2.0.1`
prestashopcorp/puik-resolver `2.0.0 -> 2.0.1`
prestashopcorp/puik-theme `2.0.0 -> 2.0.1`
prestashopcorp/puik-tailwind-preset `2.0.0 -> 2.0.1`
prestashopcorop/puik-docs `1.1.0 -> 1.1.1`