### PR TITLE
feat: [puik-alert] fix #339 - fix alert design specs (link button text), ability to add icons for buttons (Action and Link)

### DIFF
--- a/RELEASE-NOTES-V2.md
+++ b/RELEASE-NOTES-V2.md
@@ -22,7 +22,7 @@ Here is the list of available components in the Vue and Web-Components version o
 | --------------------------- | -------------- | -------------- | ---------------- |
 | Accordion                   | ✅  | ✅            |                  |
 | Accordion-group             | ✅  | ✅            |                  |
-| Alert                       | ✅  | ✅            |                  |
+| Alert                       | ✅  | ✅            |   Design:  The `puik-link` has replaced by a Link Button (text variant button) - [see updated stories for use](https://uikit.prestashop.com/?path=/docs/components-alert--docs)      |
 | Avatar                      | ✅  | ✅            |                  |
 | Badge                       | ✅  | ✅            |                  |
 | Breadcrumb                  | ✅  | ✅            |                  |

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'header-max-length': [2, 'always', 150]
+    'header-max-length': [2, 'always', 300]
   }
 };

--- a/packages/components/alert/src/alert.ts
+++ b/packages/components/alert/src/alert.ts
@@ -20,19 +20,27 @@ export interface AlertProps {
   title?: string
   description?: string
   variant?: `${PuikAlertVariants}`
-  disableBorders?: boolean
   isClosable?: boolean
+  disableBorders?: boolean
   buttonLabel?: string
-  buttonWrapLabel?: boolean
   linkLabel?: string
+  buttonWrapLabel?: boolean
+  leftIconBtn?: string
+  rightIconBtn?: string
+  leftIconLink?: string
+  rightIconLink?: string
+  internalLink?: string
+  externalLink?: string
   ariaLive?: `${PuikAriaLive}`
+  ariaLabelBtn?: string
+  ariaLabelLink?: string
   dataTest?: string
 }
 
 export type AlertEmits = {
   click: [event: Event]
-  close: [event: Event]
   clickLink: [event: Event]
+  close: [event: Event]
 };
 
 export type AlertInstance = InstanceType<typeof Alert>;

--- a/packages/components/alert/src/alert.vue
+++ b/packages/components/alert/src/alert.vue
@@ -42,17 +42,31 @@
           </p>
         </div>
       </div>
-      <PuikLink
+      <PuikButton
         v-if="linkLabel"
+        v-bind="{
+          ...(leftIconLink ? { 'left-icon': leftIconLink } : {}),
+          ...(rightIconLink ? { 'right-icon': rightIconLink } : {}),
+          ...(internalLink ? { 'to': internalLink } : {}),
+          ...(externalLink ? { 'href': externalLink } : {}),
+          ...(ariaLabelLink ? { 'aria-label': ariaLabelLink } : {}),
+        }"
         class="puik-alert__link"
         :data-test="dataTest != undefined ? `link-${dataTest}` : undefined"
         tabindex="0"
+        variant="text"
+        :wrap-label="buttonWrapLabel"
         @click="clickLink"
       >
         {{ linkLabel }}
-      </PuikLink>
+      </PuikButton>
       <PuikButton
         v-if="buttonLabel"
+        v-bind="{
+          ...(leftIconBtn ? { 'left-icon': leftIconBtn } : {}),
+          ...(rightIconBtn ? { 'right-icon': rightIconBtn } : {}),
+          ...(ariaLabelBtn ? { 'aria-label': ariaLabelBtn } : {}),
+        }"
         :variant="variant"
         :wrap-label="buttonWrapLabel"
         class="puik-alert__button"
@@ -79,7 +93,6 @@ import { computed } from 'vue';
 import { generateId } from '@prestashopcorp/puik-utils';
 import { PuikButton } from '@prestashopcorp/puik-components/button';
 import { PuikIcon } from '@prestashopcorp/puik-components/icon';
-import { PuikLink } from '@prestashopcorp/puik-components/link';
 import { PuikAriaLive } from '@prestashopcorp/puik-components/base/src/common';
 import { PuikAlertVariants, ICONS } from './alert';
 import type { AlertProps, AlertEmits } from './alert';
@@ -105,8 +118,7 @@ const clickLink = (event: Event) => emit('clickLink', event);
 
 <style lang="scss">
 @use '@prestashopcorp/puik-theme/src/base.scss';
-@use '@prestashopcorp/puik-theme/src/puik-alert.scss';
-@use '@prestashopcorp/puik-theme/src/puik-button.scss';
 @use '@prestashopcorp/puik-theme/src/puik-icon.scss';
-@use '@prestashopcorp/puik-theme/src/puik-link.scss';
+@use '@prestashopcorp/puik-theme/src/puik-button.scss';
+@use '@prestashopcorp/puik-theme/src/puik-alert.scss';
 </style>

--- a/packages/components/alert/stories/alert.stories.ts
+++ b/packages/components/alert/stories/alert.stories.ts
@@ -1,7 +1,8 @@
 import { action } from '@storybook/addon-actions';
 import { PuikAriaLive } from '@prestashopcorp/puik-components/base/src/common';
-import { PuikAlert, PuikAlertVariants } from '@prestashopcorp/puik-components';
+import { PuikAlert, PuikAlertVariants, PuikButton, PuikLink } from '@prestashopcorp/puik-components';
 import type { StoryObj, Meta, StoryFn, Args } from '@storybook/vue3';
+import { ref } from 'vue';
 
 const alertVariants = Object.values(PuikAlertVariants);
 const alertVariantsSummary = alertVariants.join('|');
@@ -14,58 +15,176 @@ export default {
   component: PuikAlert,
   argTypes: {
     title: {
-      description: 'Set the alert title'
+      description: 'Set the alert title',
+      control: 'text',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: {
+          summary: 'undefined'
+        }
+      }
     },
     description: {
-      description: 'Set the alert description (also exists as a default slot)'
+      description: 'Set the alert description (also exists as a default slot)',
+      control: 'text',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: {
+          summary: 'undefined'
+        }
+      }
+    },
+    buttonLabel: {
+      description: 'Label of the Action button',
+      control: 'text',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: {
+          summary: 'undefined'
+        }
+      }
+    },
+    linkLabel: {
+      description: 'Label of the Link button',
+      control: 'text',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: {
+          summary: 'undefined'
+        }
+      }
     },
     variant: {
       control: 'select',
       description: 'Set the alert variant',
       options: alertVariants,
       table: {
-        defaultValue: {
-          summary: 'success'
-        },
         type: {
           summary: alertVariantsSummary
-        }
-      }
-    },
-    disableBorders: {
-      description:
-        'Disable alert borders (only for info, warning, error variants)',
-      table: {
+        },
         defaultValue: {
-          summary: false
-        }
-      }
-    },
-    buttonLabel: {
-      description: 'Label of the button'
-    },
-    buttonWrapLabel: {
-      description: 'Set the carriage return of the button label',
-      table: {
-        defaultValue: {
-          summary: false
+          summary: 'success'
         }
       }
     },
     isClosable: {
-      description: 'Display a close button'
+      description: 'Display a close button which emits a `close event` on click',
+      control: 'boolean',
+      table: {
+        type: {
+          summary: 'boolean'
+        },
+        defaultValue: {
+          summary: false
+        }
+      }
+    },
+    disableBorders: {
+      description: 'Disable alert borders',
+      control: 'boolean',
+      table: {
+        type: {
+          summary: 'boolean'
+        },
+        defaultValue: {
+          summary: false
+        }
+      }
+    },
+    buttonWrapLabel: {
+      description: 'Set the carriage return for label of Action and Link buttons',
+      control: 'boolean',
+      table: {
+        type: {
+          summary: 'boolean'
+        },
+        defaultValue: {
+          summary: false
+        }
+      }
     },
     default: {
-      control: 'none',
-      description: 'Set the alert description'
+      description: 'Set the alert description via the `default slot`. Useful if you want to create a description a little more complex than a simple text and integrate other puik elements like for example a classic `puik-link` (which can be an alternative to the Link button - see example below)'
     },
-    dataTest: {
+    leftIconBtn: {
+      description: 'Set icon on the left side of the Action button with a Material Icon name - cf https://fonts.google.com/icons',
       control: 'text',
-      description:
-        'Set the data-test attribute for the alert components `title-${dataTest}` `description-${dataTest}` `button-${dataTest}` `close-${dataTest}` `link-${dataTest}`'
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: {
+          summary: 'undefined'
+        }
+      }
     },
-    linkLabel: {
-      description: 'Label of the link'
+    rightIconBtn: {
+      description: 'Set icon on the right side of the Action button with a Material Icon name - cf https://fonts.google.com/icons',
+      control: 'text',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: {
+          summary: 'undefined'
+        }
+      }
+    },
+    leftIconLink: {
+      description: 'Set icon on the left side of the Link button with a Material Icon name - cf https://fonts.google.com/icons',
+      control: 'text',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: {
+          summary: 'undefined'
+        }
+      }
+    },
+    rightIconLink: {
+      description: 'Set icon on the right side of the Link button with a Material Icon name - cf https://fonts.google.com/icons',
+      control: 'text',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: {
+          summary: 'undefined'
+        }
+      }
+    },
+    internalLink: {
+      description: 'Internal link for the Link button (use vue `router-link` under the hood)',
+      control: 'text',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: {
+          summary: 'undefined'
+        }
+      }
+    },
+    externalLink: {
+      description: 'External link for the Link button (use a native `a` tag link under the hood)',
+      control: 'text',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: {
+          summary: 'undefined'
+        }
+      }
     },
     ariaLive: {
       description: 'option for "aria-live" attribute',
@@ -79,17 +198,63 @@ export default {
           summary: alertAriaLiveSummary
         }
       }
+    },
+    ariaLabelBtn: {
+      description: 'ARIA label for the Action button',
+      control: 'text',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: {
+          summary: 'undefined'
+        }
+      }
+    },
+    ariaLabelLink: {
+      description: 'ARIA label for the Link button',
+      control: 'text',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: {
+          summary: 'undefined'
+        }
+      }
+    },
+    dataTest: {
+      control: 'text',
+      description: 'Set the data-test attribute for the alert components `title-${dataTest}` `description-${dataTest}` `button-${dataTest}` `close-${dataTest}` `link-${dataTest}`',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: {
+          summary: 'undefined'
+        }
+      }
     }
   },
   args: {
     title: 'Title',
     description: 'This is the description of the success alert.',
+    buttonLabel: 'Action',
+    linkLabel: 'Learn more',
     variant: 'success',
-    disableBorders: false,
-    buttonLabel: 'Button',
-    buttonWrapLabel: false,
     isClosable: false,
-    linkLabel: 'See more'
+    disableBorders: false,
+    buttonWrapLabel: false,
+    leftIconBtn: undefined,
+    rightIconBtn: undefined,
+    leftIconLink: undefined,
+    rightIconLink: undefined,
+    internalLink: undefined,
+    externalLink: undefined,
+    ariaLabelBtn: undefined,
+    ariaLabelLink: undefined,
+    ariaLive: 'polite',
+    dataTest: undefined
   }
 } as Meta;
 
@@ -123,32 +288,35 @@ export const Default = {
       source: {
         code: `
   <!--VueJS Snippet-->
-  <!--
-  $variants: ${alertVariantsSummary}
-  -->
   <puik-alert
     :title="title"
     :variant="$variants"
-    :disable-borders="disableBorders"
-    :button-label="buttonLabel"
-    @click="click"
+    :button-label="Action"
+    :link-label="Learn more"
+    @click="handleClickAction"
+    @click-link="handleClickLink"
+    @close="handleClose"
   >
     This is the description of the success alert
   </puik-alert>
 
   <!--HTML/CSS Snippet-->
-  <!--
-  $variants: ${alertVariantsSummary}
-  -->
-  <div class="puik-alert puik-alert--{$variants}" aria-live="{polite|assertive}">
-    <div class="puik-alert__content">
-      <span class="puik-icon puik-alert__icon">check_circle</span>
-      <div class="puik-alert__text">
-        <p class="puik-alert__title">Title</p>
-        <span class="puik-alert__description">This is the description of the success alert.</span>
+  <div class="puik-alert puik-alert--success" role="alert" aria-labelledby="title-5929" aria-describedby="description-5929" aria-live="polite" tabindex="0">
+    <div class="puik-alert__container">
+      <div class="puik-alert__content">
+        <div class="puik-icon puik-alert__icon" aria-label="check_circle icon" role="img" style="font-size: 1.25rem;">check_circle</div>
+        <div class="puik-alert__text">
+          <h4 id="title-5929" class="puik-alert__title">Title</h4>
+          <p id="description-5929" class="puik-alert__description">This is the description of the success alert.</p>
+        </div>
       </div>
+      <button class="puik-button puik-button--text puik-button--md puik-button--no-wrap puik-alert__link" role="button" tabindex="0">
+        Learn more
+      </button>
+      <button class="puik-button puik-button--success puik-button--md puik-button--no-wrap puik-alert__button" role="button">
+        Action
+      </button>
     </div>
-    <button class="puik-alert__button">Button</button>
   </div>
         `,
         language: 'html'
@@ -157,14 +325,413 @@ export const Default = {
   }
 };
 
-export const buttonWrapLabel: StoryObj = {
+export const Variants: StoryObj = {
+  render: () => ({
+    components: {
+      PuikAlert
+    },
+    template: `
+    <div class="flex flex-col space-y-4">
+        <puik-alert
+          title="Success"
+          description="this is a description"
+          variant="success"
+          button-label="Action"
+          link-label="Learn more"
+        />
+        <puik-alert
+          title="Info"
+          description="this is a description"
+          variant="info"
+          button-label="Action"
+          link-label="Learn more"
+        />        
+        <puik-alert
+          title="Warning"
+          description="this is a description"
+          variant="warning"
+          button-label="Action"
+          link-label="Learn more"
+        />
+        <puik-alert
+          title="Danger"
+          description="this is a description"
+          variant="danger"
+          button-label="Action"
+          link-label="Learn more"
+        />
+    </div>
+    `
+  }),
+
+  parameters: {
+    docs: {
+      source: {
+        code: `
+  <!--VueJS Snippet-->
+  <!--
+  $variants: ${alertVariantsSummary}
+  -->
+  <puik-alert
+    title="Success"
+    description="this is a description"
+    variant="success"
+    button-label="Action"
+    link-label="Learn more"
+  />
+  <puik-alert
+    title="Info"
+    description="this is a description"
+    variant="info"
+    button-label="Action"
+    link-label="Learn more"
+  />        
+  <puik-alert
+    title="Warning"
+    description="this is a description"
+    variant="warning"
+    button-label="Action"
+    link-label="Learn more"
+  />
+  <puik-alert
+    title="Danger"
+    description="this is a description"
+    variant="danger"
+    button-label="Action"
+    link-label="Learn more"
+  />
+    This a success alert with a title and a description.
+  </puik-alert>
+
+  <!--HTML/CSS Snippet-->
+  <div class="puik-alert puik-alert--success" role="alert" aria-labelledby="title-1437" aria-describedby="description-1437" aria-live="polite" tabindex="0">
+    <div class="puik-alert__container">
+      <div class="puik-alert__content">
+        <div class="puik-icon puik-alert__icon" aria-label="check_circle icon" role="img" style="font-size: 1.25rem;">check_circle</div>
+        <div class="puik-alert__text">
+          <h4 id="title-1437" class="puik-alert__title">Success</h4>
+          <p id="description-1437" class="puik-alert__description">this is a description</p>
+        </div>
+      </div>
+      <button class="puik-button puik-button--text puik-button--md puik-button--no-wrap puik-alert__link" role="button" tabindex="0">
+        Learn more
+      </button>
+      <button class="puik-button puik-button--success puik-button--md puik-button--no-wrap puik-alert__button" role="button">
+        Action
+      </button>
+    </div>
+    
+  </div>
+
+  <div class="puik-alert puik-alert--info" role="alert" aria-labelledby="title-1065" aria-describedby="description-1065" aria-live="polite" tabindex="0">
+    <div class="puik-alert__container">
+      <div class="puik-alert__content">
+        <div class="puik-icon puik-alert__icon" aria-label="info icon" role="img" style="font-size: 1.25rem;">info</div>
+        <div class="puik-alert__text">
+          <h4 id="title-1065" class="puik-alert__title">Info</h4>
+          <p id="description-1065" class="puik-alert__description">this is a description</p>
+        </div>
+      </div>
+      <button class="puik-button puik-button--text puik-button--md puik-button--no-wrap puik-alert__link" role="button" tabindex="0">
+        Learn more
+      </button>
+      <button class="puik-button puik-button--info puik-button--md puik-button--no-wrap puik-alert__button" role="button">
+        Action
+      </button>
+    </div>
+    
+  </div>
+
+  <div class="puik-alert puik-alert--warning" role="alert" aria-labelledby="title-6761" aria-describedby="description-6761" aria-live="polite" tabindex="0">
+    <div class="puik-alert__container">
+      <div class="puik-alert__content">
+        <div class="puik-icon puik-alert__icon" aria-label="warning icon" role="img" style="font-size: 1.25rem;">warning</div>
+        <div class="puik-alert__text">
+          <h4 id="title-6761" class="puik-alert__title">Warning</h4>
+          <p id="description-6761" class="puik-alert__description">this is a description</p>
+        </div>
+      </div>
+      <button class="puik-button puik-button--text puik-button--md puik-button--no-wrap puik-alert__link" role="button" tabindex="0">
+        Learn more
+      </button>
+      <button class="puik-button puik-button--warning puik-button--md puik-button--no-wrap puik-alert__button" role="button">
+        Action
+      </button>
+    </div>
+  </div>
+
+  <div class="puik-alert puik-alert--danger" role="alert" aria-labelledby="title-1684" aria-describedby="description-1684" aria-live="polite" tabindex="0">
+    <div class="puik-alert__container">
+      <div class="puik-alert__content">
+        <div class="puik-icon puik-alert__icon" aria-label="error icon" role="img" style="font-size: 1.25rem;">error</div>
+        <div class="puik-alert__text">
+          <h4 id="title-1684" class="puik-alert__title">Danger</h4>
+          <p id="description-1684" class="puik-alert__description">this is a description</p>
+        </div>
+      </div>
+      <button class="puik-button puik-button--text puik-button--md puik-button--no-wrap puik-alert__link" role="button" tabindex="0">
+        Learn more
+      </button>
+      <button class="puik-button puik-button--danger puik-button--md puik-button--no-wrap puik-alert__button" role="button">
+        Action
+      </button>
+    </div>
+  </div>
+        `,
+        language: 'html'
+      }
+    }
+  }
+};
+
+export const VariantsWithoutBorder: StoryObj = {
+  render: () => ({
+    components: {
+      PuikAlert
+    },
+    template: `
+    <div class="flex flex-col space-y-4">
+        <puik-alert
+          title="Success"
+          description="this is a description"
+          variant="success"
+          button-label="Action"
+          link-label="Learn more"
+          disable-borders
+        />
+        <puik-alert
+          title="Info"
+          description="this is a description"
+          variant="info"
+          button-label="Action"
+          link-label="Learn more"
+          disable-borders
+        />        
+        <puik-alert
+          title="Warning"
+          description="this is a description"
+          variant="warning"
+          button-label="Action"
+          link-label="Learn more"
+          disable-borders
+        />
+        <puik-alert
+          title="Danger"
+          description="this is a description"
+          variant="danger"
+          button-label="Action"
+          link-label="Learn more"
+          disable-borders
+        />
+    </div>
+    `
+  }),
+
+  parameters: {
+    docs: {
+      source: {
+        code: `
+  <!--VueJS Snippet-->
+  <!--
+  $variants: ${alertVariantsSummary}
+  -->
+  <puik-alert
+    title="Success"
+    description="this is a description"
+    variant="success"
+    button-label="Action"
+    link-label="Learn more"
+    disable-borders
+  />
+  <puik-alert
+    title="Info"
+    description="this is a description"
+    variant="info"
+    button-label="Action"
+    link-label="Learn more"
+    disable-borders
+  />        
+  <puik-alert
+    title="Warning"
+    description="this is a description"
+    variant="warning"
+    button-label="Action"
+    link-label="Learn more"
+    disable-borders
+  />
+  <puik-alert
+    title="Danger"
+    description="this is a description"
+    variant="danger"
+    button-label="Action"
+    link-label="Learn more"
+    disable-borders
+  />
+    This a success alert with a title and a description.
+  </puik-alert>
+
+  <!--HTML/CSS Snippet-->
+  <div class="puik-alert puik-alert--success puik-alert--no-borders" role="alert" aria-labelledby="title-5065" aria-describedby="description-5065" aria-live="polite" tabindex="0">
+    <div class="puik-alert__container">
+        <div class="puik-alert__content">
+          <div class="puik-icon puik-alert__icon" style="font-size: 1.25rem;" aria-label="check_circle icon" role="img">check_circle</div>
+          <div class="puik-alert__text">
+              <h4 id="title-5065" class="puik-alert__title">Success</h4>
+              <p id="description-5065" class="puik-alert__description">this is a description</p>
+          </div>
+        </div>
+        <button class="puik-button puik-button--text puik-button--md puik-button--no-wrap puik-alert__link" role="button" tabindex="0">
+          Learn more
+        </button>
+        <button class="puik-button puik-button--success puik-button--md puik-button--no-wrap puik-alert__button" role="button">
+          Action
+        </button>
+    </div>
+  </div>
+
+  <div class="puik-alert puik-alert--info puik-alert--no-borders" role="alert" aria-labelledby="title-574" aria-describedby="description-574" aria-live="polite" tabindex="0">
+    <div class="puik-alert__container">
+        <div class="puik-alert__content">
+          <div class="puik-icon puik-alert__icon" style="font-size: 1.25rem;" aria-label="info icon" role="img">info</div>
+          <div class="puik-alert__text">
+              <h4 id="title-574" class="puik-alert__title">Info</h4>
+              <p id="description-574" class="puik-alert__description">this is a description</p>
+          </div>
+        </div>
+        <button class="puik-button puik-button--text puik-button--md puik-button--no-wrap puik-alert__link" role="button" tabindex="0">
+          Learn more
+        </button>
+        <button class="puik-button puik-button--info puik-button--md puik-button--no-wrap puik-alert__button" role="button">
+          Action
+        </button>
+    </div>
+  </div>
+
+  <div class="puik-alert puik-alert--warning puik-alert--no-borders" role="alert" aria-labelledby="title-5783" aria-describedby="description-5783" aria-live="polite" tabindex="0">
+    <div class="puik-alert__container">
+        <div class="puik-alert__content">
+          <div class="puik-icon puik-alert__icon" style="font-size: 1.25rem;" aria-label="warning icon" role="img">warning</div>
+          <div class="puik-alert__text">
+              <h4 id="title-5783" class="puik-alert__title">Warning</h4>
+              <p id="description-5783" class="puik-alert__description">this is a description</p>
+          </div>
+        </div>
+        <button class="puik-button puik-button--text puik-button--md puik-button--no-wrap puik-alert__link" role="button" tabindex="0">
+          Learn more
+        </button>
+        <button class="puik-button puik-button--warning puik-button--md puik-button--no-wrap puik-alert__button" role="button">
+          Action
+        </button>
+    </div>
+  </div>
+
+  <div class="puik-alert puik-alert--danger puik-alert--no-borders" role="alert" aria-labelledby="title-8888" aria-describedby="description-8888" aria-live="polite" tabindex="0">
+    <div class="puik-alert__container">
+        <div class="puik-alert__content">
+          <div class="puik-icon puik-alert__icon" style="font-size: 1.25rem;" aria-label="error icon" role="img">error</div>
+          <div class="puik-alert__text">
+              <h4 id="title-8888" class="puik-alert__title">Danger</h4>
+              <p id="description-8888" class="puik-alert__description">this is a description</p>
+          </div>
+        </div>
+        <button class="puik-button puik-button--text puik-button--md puik-button--no-wrap puik-alert__link" role="button" tabindex="0">
+          Learn more
+        </button>
+        <button class="puik-button puik-button--danger puik-button--md puik-button--no-wrap puik-alert__button" role="button">
+          Action
+        </button>
+    </div>
+  </div>
+        `,
+        language: 'html'
+      }
+    }
+  }
+};
+
+export const IsClosable = {
+  render: () => ({
+    components: {
+      PuikAlert,
+      PuikButton
+    },
+    setup() {
+      const showAlert = ref(true);
+      return { showAlert };
+    },
+
+    template: `
+      <puik-alert
+        v-if="showAlert"
+        title="Closable alert"
+        description="Click on close button"
+        variant="info"
+        button-label="Action"
+        link-label="Learn more"
+        is-closable
+        @close="showAlert = false"
+      />
+
+      <puik-button
+        v-if="!showAlert"
+        @click="showAlert = !showAlert">
+          refresh alert
+      </puik-button>
+    `
+  }),
+
+  parameters: {
+    docs: {
+      source: {
+        code: `
+  <!--VueJS Snippet-->
+  // const showAlert = ref(true)
+
+  <puik-alert
+    v-if="showAlert"
+    title="Closable alert"
+    description="this is a description"
+    variant="info"
+    button-label="Action"
+    link-label="Learn more"
+    is-closable
+    @close="showAlert = false"
+  />
+
+  <!--HTML/CSS Snippet-->
+  <div class="puik-alert puik-alert--info" role="alert" aria-labelledby="title-9572" aria-describedby="description-9572" aria-live="polite" tabindex="0">
+    <div class="puik-alert__container">
+        <div class="puik-alert__content">
+          <div class="puik-icon puik-alert__icon" style="font-size: 1.25rem;" aria-label="info icon" role="img">info</div>
+          <div class="puik-alert__text">
+              <h4 id="title-9572" class="puik-alert__title">Closable alert</h4>
+              <p id="description-9572" class="puik-alert__description">this is a description</p>
+          </div>
+        </div>
+        <button class="puik-button puik-button--text puik-button--md puik-button--no-wrap puik-alert__link" role="button" tabindex="0">
+          Learn more
+        </button>
+        <button class="puik-button puik-button--info puik-button--md puik-button--no-wrap puik-alert__button" role="button">
+          Action
+        </button>
+    </div>
+    <div class="puik-icon puik-alert__close" style="font-size: 1.5rem;" aria-label="close icon" role="img">close</div>
+  </div>
+        `,
+        language: 'html'
+      }
+    }
+  }
+};
+
+export const ButtonWrapLabel: StoryObj = {
   render: () => ({
     components: {
       PuikAlert
     },
     template: `
       <div class="flex flex-col space-y-4">
-       <puik-alert title="buttonWrapLabel to true" button-label="Button with a very long label" button-wrap-Label>
+       <puik-alert variant="info" title="buttonWrapLabel to true" button-label="Action Button with a very long label" link-label="Link button with a very long label" :button-wrap-Label="true">
         This an alert with a very long description.
         This an alert with a very long description.
         This an alert with a very long description.
@@ -175,7 +742,7 @@ export const buttonWrapLabel: StoryObj = {
         This an alert with a very long description.
         This an alert with a very long description.
        </puik-alert>
-       <puik-alert title="buttonWrapLabel to false (by default)" button-label="Button with a very long label">
+       <puik-alert variant="info" title="buttonWrapLabel to false (by default)" button-label="Action button with a very long label" link-label="Link button with a very long label">
         This an alert with a very long description.
         This an alert with a very long description.
         This an alert with a very long description.
@@ -197,9 +764,9 @@ export const buttonWrapLabel: StoryObj = {
   <!--VueJS Snippet-->
   <puik-alert
     title="buttonWrapLabel to true"
-    button-label="Button with a very long label"
+    button-label="Action button with a very long label"
+    link-label="Link button with a very long label"
     button-wrap-Label
-    @click="click"
   >
     This an alert with a very long description.
     This an alert with a very long description.
@@ -214,8 +781,8 @@ export const buttonWrapLabel: StoryObj = {
 
   <puik-alert
     title="buttonWrapLabel to false (by default)"
-    button-label="Button with a very long label"
-    @click="click"
+    button-label="Action button with a very long label"
+    link-label="Link button with a very long label"
   >
     This an alert with a very long description.
     This an alert with a very long description.
@@ -229,31 +796,61 @@ export const buttonWrapLabel: StoryObj = {
   </puik-alert>
 
   <!--HTML/CSS Snippet-->
-<div class="puik-alert__container">
-  <div class="puik-alert__content">
-      <div class="puik-icon puik-alert__icon" style="font-size: 1.25rem;">check_circle</div>
-      <div class="puik-alert__text">
-          <p class="puik-alert__title">buttonWrapLabel to true</p>
-          <span class="puik-alert__description"> This an alert with a very long description. This an alert with a very long description. This an alert with a very long description. This an alert with a very long description. This an alert with a very long description. This an alert with a very long description. This an alert with a very long description. This an alert with a very long description. This an alert with a very long description. </span>
-      </div>
+  <div class="puik-alert puik-alert--info" role="alert" aria-labelledby="title-3605" aria-describedby="description-3605" aria-live="polite" tabindex="0">
+    <div class="puik-alert__container">
+        <div class="puik-alert__content">
+          <div class="puik-icon puik-alert__icon" style="font-size: 1.25rem;" aria-label="info icon" role="img">info</div>
+          <div class="puik-alert__text">
+              <h4 id="title-3605" class="puik-alert__title">buttonWrapLabel to true</h4>
+              <p id="description-3605" class="puik-alert__description">
+                This an alert with a very long description.
+                This an alert with a very long description.
+                This an alert with a very long description.
+                This an alert with a very long description.
+                This an alert with a very long description.
+                This an alert with a very long description.
+                This an alert with a very long description.
+                This an alert with a very long description.
+                This an alert with a very long description.
+              </p>
+          </div>
+        </div>
+        <button class="puik-button puik-button--text puik-button--md puik-alert__link" role="button" tabindex="0">
+          Link button with a very long label
+        </button>
+        <button class="puik-button puik-button--info puik-button--md puik-alert__button" role="button">
+          Action Button with a very long label
+        </button>
+    </div>
   </div>
-  <button class="puik-button puik-button--success puik-button--md puik-alert__button">
-      Button with a very long label
-  </button>
-</div>
 
-<div class="puik-alert__container">
-  <div class="puik-alert__content">
-      <div class="puik-icon puik-alert__icon" style="font-size: 1.25rem;">check_circle</div>
-      <div class="puik-alert__text">
-          <p class="puik-alert__title">buttonWrapLabel to false (by default)</p>
-          <span class="puik-alert__description"> This an alert with a very long description. This an alert with a very long description. This an alert with a very long description. This an alert with a very long description. This an alert with a very long description. This an alert with a very long description. This an alert with a very long description. This an alert with a very long description. This an alert with a very long description. </span>
-      </div>
+  <div class="puik-alert puik-alert--info" role="alert" aria-labelledby="title-2321" aria-describedby="description-2321" aria-live="polite" tabindex="0">
+    <div class="puik-alert__container">
+        <div class="puik-alert__content">
+          <div class="puik-icon puik-alert__icon" style="font-size: 1.25rem;" aria-label="info icon" role="img">info</div>
+          <div class="puik-alert__text">
+              <h4 id="title-2321" class="puik-alert__title">buttonWrapLabel to false (by default)</h4>
+              <p id="description-2321" class="puik-alert__description">
+                This an alert with a very long description.
+                This an alert with a very long description.
+                This an alert with a very long description.
+                This an alert with a very long description.
+                This an alert with a very long description.
+                This an alert with a very long description.
+                This an alert with a very long description.
+                This an alert with a very long description.
+                This an alert with a very long description.
+              </p>
+          </div>
+        </div>
+        <button class="puik-button puik-button--text puik-button--md puik-button--no-wrap puik-alert__link" role="button" tabindex="0">
+          Link button with a very long label
+        </button>
+        <button class="puik-button puik-button--info puik-button--md puik-button--no-wrap puik-alert__button" role="button">
+          Action button with a very long label
+        </button>
+    </div>
   </div>
-  <button class="puik-button puik-button--success puik-button--md puik-button--no-wrap puik-alert__button">
-      Button with a very long label
-  </button>
-</div>
         `,
         language: 'html'
       }
@@ -261,18 +858,198 @@ export const buttonWrapLabel: StoryObj = {
   }
 };
 
-export const Success: StoryObj = {
+export const ActionAndLinkButtonsWithIcon: StoryObj = {
   render: () => ({
     components: {
       PuikAlert
     },
+
     template: `
-      <div class="flex flex-col space-y-4">
-       <puik-alert title="Title">This a success alert with a title and a description.</puik-alert>
-       <puik-alert>This a success alert with only a description.</puik-alert>
-       <puik-alert title="Title" button-label="Button">This a success alert with a title and a description and a button.</puik-alert>
-       <puik-alert button-label="Button">This a success alert with a description and a button.</puik-alert>
+    <div class="flex flex-col space-y-4">
+      <puik-alert
+        title="Right icon btn"
+        variant="info"
+        button-label="Action"
+        right-icon-btn="open_in_new"
+      >
+        This is the description
+      </puik-alert>
+      
+      <puik-alert
+        title="Left icon btn"
+        variant="info"
+        button-label="Action"
+        left-icon-btn="open_in_new"
+      >
+        This is the description
+      </puik-alert>
+      
+      <puik-alert
+        title="Right icon link"
+        variant="info"
+        link-label="Learn more"
+        right-icon-link="open_in_new"
+      >
+        This is the description
+      </puik-alert>
+      
+      <puik-alert
+        title="Left icon link"
+        variant="info"
+        link-label="Learn more"
+        left-icon-link="open_in_new"
+      >
+        This is the description
+      </puik-alert>
+    </div>
+    `
+  }),
+
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<!--VueJS Snippet-->
+<puik-alert
+  title="Right icon btn"
+  variant="info"
+  button-label="Action"
+  right-icon-btn="open_in_new"
+>
+  This is the description
+</puik-alert>
+
+<puik-alert
+  title="Left icon btn"
+  variant="info"
+  button-label="Action"
+  left-icon-btn="open_in_new"
+>
+  This is the description
+</puik-alert>
+
+<puik-alert
+  title="Right icon link"
+  variant="info"
+  link-label="Learn more"
+  right-icon-link="open_in_new"
+>
+  This is the description
+</puik-alert>
+
+<puik-alert
+  title="Left icon link"
+  variant="info"
+  link-label="Learn more"
+  left-icon-link="open_in_new"
+>
+  This is the description
+</puik-alert>
+
+<!--HTML/CSS Snippet-->
+<div class="puik-alert puik-alert--info" role="alert" aria-labelledby="title-7222" aria-describedby="description-7222" aria-live="polite" tabindex="0">
+   <div class="puik-alert__container">
+      <div class="puik-alert__content">
+         <div class="puik-icon puik-alert__icon" style="font-size: 1.25rem;" aria-label="info icon" role="img">info</div>
+         <div class="puik-alert__text">
+            <h4 id="title-7222" class="puik-alert__title">Right icon btn</h4>
+            <p id="description-7222" class="puik-alert__description"> This is the description </p>
+         </div>
       </div>
+      <button class="puik-button puik-button--info puik-button--md puik-button--no-wrap puik-alert__button" role="button">
+         Action
+         <div class="puik-icon puik-button__right-icon" style="font-size: 1.25rem;" aria-label="open_in_new icon" role="img" aria-hidden="true">open_in_new</div>
+      </button>
+   </div>
+</div>
+
+<div class="puik-alert puik-alert--info" role="alert" aria-labelledby="title-3413" aria-describedby="description-3413" aria-live="polite" tabindex="0">
+   <div class="puik-alert__container">
+      <div class="puik-alert__content">
+         <div class="puik-icon puik-alert__icon" style="font-size: 1.25rem;" aria-label="info icon" role="img">info</div>
+         <div class="puik-alert__text">
+            <h4 id="title-3413" class="puik-alert__title">Left icon btn</h4>
+            <p id="description-3413" class="puik-alert__description"> This is the description </p>
+         </div>
+      </div>
+      <button class="puik-button puik-button--info puik-button--md puik-button--no-wrap puik-alert__button" role="button">
+         <div class="puik-icon puik-button__left-icon" style="font-size: 1.25rem;" aria-label="open_in_new icon" role="img" aria-hidden="true">open_in_new</div>
+         Action
+      </button>
+   </div>
+</div>
+
+<div class="puik-alert puik-alert--info" role="alert" aria-labelledby="title-34" aria-describedby="description-34" aria-live="polite" tabindex="0">
+   <div class="puik-alert__container">
+      <div class="puik-alert__content">
+         <div class="puik-icon puik-alert__icon" style="font-size: 1.25rem;" aria-label="info icon" role="img">info</div>
+         <div class="puik-alert__text">
+            <h4 id="title-34" class="puik-alert__title">Right icon link</h4>
+            <p id="description-34" class="puik-alert__description"> This is the description </p>
+         </div>
+      </div>
+      <button class="puik-button puik-button--text puik-button--md puik-button--no-wrap puik-alert__link" role="button" tabindex="0">
+         Learn more
+         <div class="puik-icon puik-button__right-icon" style="font-size: 1.25rem;" aria-label="open_in_new icon" role="img" aria-hidden="true">open_in_new</div>
+      </button>
+   </div>
+</div>
+
+<div class="puik-alert puik-alert--info" role="alert" aria-labelledby="title-4747" aria-describedby="description-4747" aria-live="polite" tabindex="0">
+   <div class="puik-alert__container">
+      <div class="puik-alert__content">
+         <div class="puik-icon puik-alert__icon" style="font-size: 1.25rem;" aria-label="info icon" role="img">info</div>
+         <div class="puik-alert__text">
+            <h4 id="title-4747" class="puik-alert__title">Left icon link</h4>
+            <p id="description-4747" class="puik-alert__description"> This is the description </p>
+         </div>
+      </div>
+      <button class="puik-button puik-button--text puik-button--md puik-button--no-wrap puik-alert__link" role="button" tabindex="0">
+         <div class="puik-icon puik-button__left-icon" style="font-size: 1.25rem;" aria-label="open_in_new icon" role="img" aria-hidden="true">open_in_new</div>
+         Learn more
+      </button>
+   </div>
+</div>
+      `,
+        language: 'html'
+      }
+    }
+  }
+};
+
+export const InternalAndExternalLink = {
+  render: () => ({
+    components: {
+      PuikAlert,
+      PuikButton
+    },
+    setup() {
+      const showAlert = ref(true);
+      return { showAlert };
+    },
+
+    template: `
+    <div class="flex flex-col space-y-4">
+      <puik-alert
+        title="Internal link"
+        variant="info"
+        link-label="Learn more"
+        internal-link="#"
+      >
+        Use vue <code>router-link</code> under the hood
+      </puik-alert>
+
+      <puik-alert
+        title="External link"
+        description="this is a description"
+        variant="info"
+        link-label="Learn more"
+        right-icon-link="open_in_new"
+        external-link="https://example.com"
+      >
+        Use native <code>a</code> tag under the hood
+      </puik-alert>
+    </div>
     `
   }),
 
@@ -282,123 +1059,57 @@ export const Success: StoryObj = {
         code: `
   <!--VueJS Snippet-->
   <puik-alert
-    title="Title"
-    variant="success"
-    button-label="Button"
-    @click="click"
-  >
-    This a success alert with a title and a description.
-  </puik-alert>
-
-  <!--HTML/CSS Snippet-->
-  <div class="puik-alert puik-alert--success" aria-live="polite">
-    <div class="puik-alert__content">
-      <span class="puik-icon puik-alert__icon">check_circle</span>
-      <div class="puik-alert__text">
-        <p class="puik-alert__title">Title</p>
-        <span class="puik-alert__description">This a success alert with a title and a description.</span>
-      </div>
-    </div>
-    <button class="puik-alert__button">Button</button>
-  </div>
-        `,
-        language: 'html'
-      }
-    }
-  }
-};
-
-export const Warning: StoryObj = {
-  render: () => ({
-    components: {
-      PuikAlert
-    },
-    template: `
-      <div class="flex flex-col space-y-4">
-        <puik-alert variant="warning" title="Title">This a warning alert with a title and a description.</puik-alert>
-        <puik-alert title="Title" variant="warning" :disable-borders="true">This a warning alert with disabled borders</puik-alert>
-        <puik-alert variant="warning">This a warning alert with only a description.</puik-alert>
-        <puik-alert variant="warning" title="Title" button-label="Button">This a warning alert with a title and a description and a button.</puik-alert>
-        <puik-alert variant="warning" button-label="Button">This a warning alert with a description and a button.</puik-alert>
-      </div>
-    `
-  }),
-
-  parameters: {
-    docs: {
-      source: {
-        code: `
-  <!--VueJS Snippet-->
-  <puik-alert
-    title="Title"
-    variant="warning"
-    :disable-borders="true|false"
-    button-label="Button"
-    @click="click"
-  >
-    This a warning alert with a title and a description.
-  </puik-alert>
-
-  <!--HTML/CSS Snippet-->
-  <div class="puik-alert puik-alert--warning puik-alert--no-borders" aria-live="polite">
-    <div class="puik-alert__content">
-      <span class="puik-icon puik-alert__icon">warning</span>
-      <div class="puik-alert__text">
-        <p class="puik-alert__title">Title</p>
-        <span class="puik-alert__description">This a warning alert with a title and a description.</span>
-      </div>
-    </div>
-    <button class="puik-alert__button">Button</button>
-  </div>
-        `,
-        language: 'html'
-      }
-    }
-  }
-};
-
-export const Info: StoryObj = {
-  render: () => ({
-    components: {
-      PuikAlert
-    },
-    template: `
-      <div class="flex flex-col space-y-4">
-       <puik-alert variant="info" title="Title">This a info alert with a title and a description.</puik-alert>
-       <puik-alert variant="info" title="Title" :disable-borders="true">This a info alert with disabled borders</puik-alert>
-       <puik-alert variant="info">This a info alert with only a description.</puik-alert>
-       <puik-alert variant="info" title="Title" button-label="Button">This a info alert with a title and a description and a button.</puik-alert>
-       <puik-alert variant="info" button-label="Button">This a info alert with a description and a button.</puik-alert>
-      </div>
-    `
-  }),
-
-  parameters: {
-    docs: {
-      source: {
-        code: `
-        <!--VueJS Snippet-->
-  <puik-alert
-    title="Title"
+    title="Internal link"
     variant="info"
-    :disable-borders="true|false"
-    button-label="Button"
-    @click="click"
+    link-label="Learn more"
+    internal-link="#"
   >
-    This a info alert with a title and a description.
+    Use vue <code>router-link</code> under the hood
+  </puik-alert>
+
+  <puik-alert
+    title="External link"
+    description="this is a description"
+    variant="info"
+    link-label="Learn more"
+    right-icon-link="open_in_new"
+    external-link="https://example.com"
+  >
+    Use native <code>a</code> tag under the hood
   </puik-alert>
 
   <!--HTML/CSS Snippet-->
-  <div class="puik-alert puik-alert--info puik-alert--no-borders" aria-live="polite">
-    <div class="puik-alert__content">
-      <span class="puik-icon puik-alert__icon">info</span>
-      <div class="puik-alert__text">
-        <p class="puik-alert__title">Title</p>
-        <span class="puik-alert__description">This a info alert with a title and a description.</span>
-      </div>
+  <div class="puik-alert puik-alert--info" role="alert" aria-labelledby="title-4259" aria-describedby="description-4259" aria-live="polite" tabindex="0">
+    <div class="puik-alert__container">
+        <div class="puik-alert__content">
+          <div class="puik-icon puik-alert__icon" style="font-size: 1.25rem;" aria-label="info icon" role="img">info</div>
+          <div class="puik-alert__text">
+              <h4 id="title-4259" class="puik-alert__title">Internal link</h4>
+              <p id="description-4259" class="puik-alert__description"> Use vue <code>router-link</code> under the hood </p>
+          </div>
+        </div>
+        <router-link to="#" class="puik-button puik-button--text puik-button--md puik-button--no-wrap puik-alert__link" role="button" disabled="false" tabindex="0">
+          Learn more
+        </router-link>
     </div>
-    <button class="puik-alert__button">Button</button>
   </div>
+
+  <div class="puik-alert puik-alert--info" role="alert" aria-labelledby="title-2136" aria-describedby="description-2136" aria-live="polite" tabindex="0">
+    <div class="puik-alert__container">
+        <div class="puik-alert__content">
+          <div class="puik-icon puik-alert__icon" style="font-size: 1.25rem;" aria-label="info icon" role="img">info</div>
+          <div class="puik-alert__text">
+              <h4 id="title-2136" class="puik-alert__title">External link</h4>
+              <p id="description-2136" class="puik-alert__description"> Use native <code>a</code> tag under the hood </p>
+          </div>
+        </div>
+        <a href="https://example.com" class="puik-button puik-button--text puik-button--md puik-button--no-wrap puik-alert__link" role="button" disabled="false" tabindex="0">
+          Learn more
+          <div class="puik-icon puik-button__right-icon" style="font-size: 1.25rem;" aria-label="open_in_new icon" role="img" aria-hidden="true">open_in_new</div>
+        </a>
+    </div>
+</div>
+
         `,
         language: 'html'
       }
@@ -406,19 +1117,36 @@ export const Info: StoryObj = {
   }
 };
 
-export const Danger: StoryObj = {
+export const UseDefaultSlotForDescription = {
   render: () => ({
     components: {
-      PuikAlert
+      PuikAlert,
+      PuikButton,
+      PuikLink
     },
+    setup() {
+      const showAlert = ref(true);
+      return { showAlert };
+    },
+
     template: `
-      <div class="flex flex-col space-y-4">
-       <puik-alert variant="danger" title="Title">This a danger alert with a title and a description.</puik-alert>
-       <puik-alert variant="danger" title="Title" :disable-borders="true">This a danger alert with disabled borders</puik-alert>
-       <puik-alert variant="danger">This a danger alert with only a description.</puik-alert>
-       <puik-alert variant="danger" title="Title" button-label="Button">This a danger alert with a title and a description and a button.</puik-alert>
-       <puik-alert variant="danger" button-label="Button">This a danger alert with a description and a button.</puik-alert>
-      </div>
+      <puik-alert
+        title="Description in default slot"
+        variant="info"
+        button-label="Action"
+      >
+        <div class="flex flex-col space-y-1">
+          <p>
+            This is a description writes in the default slot
+          </p>
+          <puik-link
+            target="_blank"
+            href="https://example.com"
+          >
+            use a puik-link in description for example
+          </puik-link>
+        </div>
+      </puik-alert>
     `
   }),
 
@@ -428,26 +1156,146 @@ export const Danger: StoryObj = {
         code: `
   <!--VueJS Snippet-->
   <puik-alert
-    title="Title"
-    variant="danger"
-    :disable-borders="true|false"
-    button-label="Button"
-    @click="click"
+    title="Description in default slot"
+    variant="info"
+    button-label="Action"
   >
-    This a info alert with a title and a description.
+    <div class="flex flex-col space-y-1">
+      <p>
+        This is a description writes in the default slot
+      </p>
+      <puik-link
+        target="_blank"
+        href="https://example.com"
+      >
+        use a puik-link in description for example
+      </puik-link>
+    </div>
   </puik-alert>
 
   <!--HTML/CSS Snippet-->
-  <div class="puik-alert puik-alert--danger puik-alert--no-borders" aria-live="polite">
-    <div class="puik-alert__content">
-      <span class="puik-icon puik-alert__icon">danger</span>
-      <div class="puik-alert__text">
-        <p class="puik-alert__title">Title</p>
-        <span class="puik-alert__description">This a danger alert with a title and a description.</span>
-      </div>
+  <div class="puik-alert puik-alert--info" role="alert" aria-labelledby="title-7176" aria-describedby="description-7176" aria-live="polite" tabindex="0">
+    <div class="puik-alert__container">
+        <div class="puik-alert__content">
+          <div class="puik-icon puik-alert__icon" style="font-size: 1.25rem;" aria-label="info icon" role="img">info</div>
+          <div class="puik-alert__text">
+              <h4 id="title-7176" class="puik-alert__title">Description in default slot</h4>
+              <p id="description-7176" class="puik-alert__description">
+              <div class="flex flex-col space-y-1">
+                <p> This is a description writes in the default slot </p>
+                <a href="https://example.com" target="_blank" class="puik-link puik-link--md" role="link"> use a puik-link in description for example <span class="puik-link__target__icon" aria-hidden="true">open_in_new</span></a>
+              </div>
+              </p>
+          </div>
+        </div>
+        <button class="puik-button puik-button--info puik-button--md puik-button--no-wrap puik-alert__button" role="button">
+          Action<!--v-if--><!--v-if-->
+        </button>
     </div>
-    <button class="puik-alert__button">Button</button>
   </div>
+        `,
+        language: 'html'
+      }
+    }
+  }
+};
+
+export const Events = {
+  render: () => ({
+    components: {
+      PuikAlert
+    },
+    setup() {
+      const eventEmitted = ref('Click on Action, Link or Close button');
+      const variant = ref('info');
+      const title = ref('Handle Events');
+
+      const successTriggered = (msg: string) => {
+        eventEmitted.value = msg;
+        title.value = msg;
+        variant.value = 'success';
+        setTimeout(() => {
+          eventEmitted.value = 'Click on Action, Link or Close button';
+          title.value = 'Handle Events';
+          variant.value = 'info';
+        }, 1000);
+      };
+
+      const handleClose = () => {
+        successTriggered('close event triggered !');
+      };
+      const handleClickAction = () => {
+        successTriggered('click event triggered !');
+      };
+      const handleClickLink = () => {
+        successTriggered('click-link event triggered !');
+      };
+      return { eventEmitted, title, variant, successTriggered, handleClose, handleClickAction, handleClickLink };
+    },
+
+    template: `
+    <puik-alert
+      :title="title"
+      :variant="variant"
+      button-label="Action"
+      link-label="Learn more"
+      is-closable
+      @close="handleClose"
+      @click="handleClickAction"
+      @click-link="handleClickLink"
+    >
+      {{ eventEmitted }}
+    </puik-alert>
+    `
+  }),
+
+  parameters: {
+    docs: {
+      source: {
+        code: `
+  <!--VueJS Snippet-->
+  <!-- 
+      const eventEmitted = ref('Click on Action, Link or Close button');
+      const variant = ref('info');
+      const title = ref('Handle Events');
+
+      const successTriggered = (msg: string) => {
+        eventEmitted.value = msg;
+        title.value = msg;
+        variant.value = 'success';
+        setTimeout(() => {
+          eventEmitted.value = 'Click on Action, Link or Close button';
+          title.value = 'Handle Events';
+          variant.value = 'info';
+        }, 1000);
+      };
+
+      const handleClose = () => {
+        successTriggered('close event triggered !');
+      };
+      const handleClickAction = () => {
+        successTriggered('click event triggered !');
+      };
+      const handleClickLink = () => {
+        successTriggered('click-link event triggered !');
+      };
+  -->
+
+  <puik-alert
+    :title="title"
+    :variant="variant"
+    button-label="Action"
+    link-label="Learn more"
+    is-closable
+    @close="handleClose"
+    @click="handleClickAction"
+    @click-link="handleClickLink"
+  >
+    {{ eventEmitted }}
+  </puik-alert>
+
+  <!--HTML/CSS Snippet-->
+
         `,
         language: 'html'
       }

--- a/packages/components/alert/test/alert.spec.ts
+++ b/packages/components/alert/test/alert.spec.ts
@@ -1,7 +1,7 @@
 import { mount, ComponentMountingOptions, VueWrapper } from '@vue/test-utils';
 import { describe, it, expect } from 'vitest';
 import { faker } from '@faker-js/faker';
-import { PuikAlert, AlertProps } from '@prestashopcorp/puik-components';
+import { PuikAlert, AlertProps, PuikAlertVariants } from '@prestashopcorp/puik-components';
 
 describe('Alert tests', () => {
   let wrapper: VueWrapper<any>;
@@ -12,6 +12,11 @@ describe('Alert tests', () => {
   const findDesc = () => wrapper.find('.puik-alert__description');
   const findCloseButton = () => wrapper.find('.puik-alert__close');
   const findLink = () => wrapper.find('.puik-alert__link');
+  const findLeftButtonIcon = () => wrapper.find('.puik-alert__button .puik-button__left-icon');
+  const findRightButtonIcon = () => wrapper.find('.puik-alert__button .puik-button__right-icon');
+  const findLeftLinkIcon = () => wrapper.find('.puik-alert__link .puik-button__left-icon');
+  const findRightLinkIcon = () => wrapper.find('.puik-alert__link .puik-button__right-icon');
+  const findIcon = () => wrapper.find('.puik-alert__icon');
 
   const factory = (
     props?: AlertProps,
@@ -28,14 +33,24 @@ describe('Alert tests', () => {
     expect(wrapper).toBeTruthy();
   });
 
-  it('should display an success alert by default', () => {
+  it('should display a success alert by default', () => {
     factory();
     expect(findAlert().classes()).toContain('puik-alert--success');
   });
 
   it('should display a warning alert', () => {
-    factory({ variant: 'warning' });
+    factory({ variant: PuikAlertVariants.Warning });
     expect(findAlert().classes()).toContain('puik-alert--warning');
+  });
+
+  it('should display a danger alert', () => {
+    factory({ variant: PuikAlertVariants.Danger });
+    expect(findAlert().classes()).toContain('puik-alert--danger');
+  });
+
+  it('should display an info alert', () => {
+    factory({ variant: PuikAlertVariants.Info });
+    expect(findAlert().classes()).toContain('puik-alert--info');
   });
 
   it('should set the button label wrap to false', () => {
@@ -51,7 +66,7 @@ describe('Alert tests', () => {
   });
 
   it('should display a link which emits the clickLink event on click', async () => {
-    factory({ linkLabel: 'See more' });
+    factory({ linkLabel: 'Learn more' });
     expect(findLink().exists()).toBeTruthy();
     await findLink().trigger('click');
     expect(wrapper.emitted('clickLink')).toBeTruthy();
@@ -91,7 +106,7 @@ describe('Alert tests', () => {
       title: faker.lorem.word(2),
       description: faker.lorem.sentence(60),
       buttonLabel: 'Button',
-      linkLabel: 'See more',
+      linkLabel: 'Learn more',
       isClosable: true,
       dataTest: 'alert'
     });
@@ -124,5 +139,60 @@ describe('Alert tests', () => {
       ariaLive: 'assertive'
     });
     expect(findAlert().attributes('aria-live')).toBe('assertive');
+  });
+
+  it('should display the correct icon for each variant', () => {
+    const variants = [PuikAlertVariants.Success, PuikAlertVariants.Warning, PuikAlertVariants.Danger, PuikAlertVariants.Info];
+    variants.forEach(variant => {
+      factory({ variant });
+      expect(findIcon().exists()).toBeTruthy();
+    });
+  });
+
+  it('should not render optional elements when props are not provided', () => {
+    factory();
+    expect(findButton().exists()).toBeFalsy();
+    expect(findLink().exists()).toBeFalsy();
+    expect(findCloseButton().exists()).toBeFalsy();
+  });
+
+  it('should set the internal link correctly', () => {
+    factory({ linkLabel: 'Learn more', internalLink: '/internal' });
+    expect(findLink().attributes('to')).toBe('/internal');
+  });
+
+  it('should set the external link correctly', () => {
+    factory({ linkLabel: 'Learn more', externalLink: 'https://example.com' });
+    expect(findLink().attributes('href')).toBe('https://example.com');
+  });
+
+  it('should set the aria-label for the button correctly', () => {
+    factory({ buttonLabel: 'Button', ariaLabelBtn: 'Button aria label' });
+    expect(findButton().attributes('aria-label')).toBe('Button aria label');
+  });
+
+  it('should set the aria-label for the link correctly', () => {
+    factory({ linkLabel: 'Learn more', ariaLabelLink: 'Link aria label' });
+    expect(findLink().attributes('aria-label')).toBe('Link aria label');
+  });
+
+  it('should display the left icon for the button', () => {
+    factory({ buttonLabel: 'Button', leftIconBtn: 'favorite' });
+    expect(findLeftButtonIcon().classes()).toContain('puik-button__left-icon');
+  });
+
+  it('should display the right icon for the button', () => {
+    factory({ buttonLabel: 'Button', rightIconBtn: 'favorite' });
+    expect(findRightButtonIcon().classes()).toContain('puik-button__right-icon');
+  });
+
+  it('should display the left icon for the link', () => {
+    factory({ linkLabel: 'Learn more', leftIconLink: 'favorite' });
+    expect(findLeftLinkIcon().classes()).toContain('puik-button__left-icon');
+  });
+
+  it('should display the right icon for the link', () => {
+    factory({ linkLabel: 'Learn more', rightIconLink: 'favorite' });
+    expect(findRightLinkIcon().classes()).toContain('puik-button__right-icon');
   });
 });

--- a/packages/theme/src/puik-alert.scss
+++ b/packages/theme/src/puik-alert.scss
@@ -7,11 +7,21 @@
     .puik-alert__icon {
       @apply text-green;
     }
+    .puik-button--text{
+      &:hover {
+        @apply bg-green-100;
+      }
+    }
   }
   &--warning {
     @apply bg-yellow-50 border-yellow;
     .puik-alert__icon {
       @apply text-yellow;
+    }
+    .puik-button--text{
+      &:hover {
+        @apply bg-yellow-100;
+      }
     }
   }
   &--danger {
@@ -19,18 +29,28 @@
     .puik-alert__icon {
       @apply text-red;
     }
+    .puik-button--text{
+      &:hover {
+        @apply bg-red-100;
+      }
+    }
   }
   &--info {
     @apply bg-blue-50 border-blue;
     .puik-alert__icon {
       @apply text-blue;
     }
+    .puik-button--text{
+      &:hover {
+        @apply bg-blue-100;
+      }
+    }
   }
   &--no-borders {
     @apply border-0;
   }
   &__container {
-    @apply flex flex-col lg:flex-row lg:items-start w-full;
+    @apply flex flex-col space-y-1 lg:flex-row lg:items-start lg:space-x-1 w-full;
   }
   &__content {
     @apply flex flex-row flex-grow;
@@ -53,8 +73,5 @@
   }
   &__close {
     @apply ml-4 cursor-pointer leading-none;
-  }
-  &__link {
-    @apply flex-none leading-6 w-fit block ml-9 pl-0 m-2 lg:mx-4 lg:pl-0 lg:truncate lg:max-w-[320px];
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
### Description

:warning: fix alert design specs:  by replacing the link (puik-link) by a Link Button (text variant)

:warning:  Finally no action slot to limit BC
 
News optional props ([see updated stories for use](https://6267e986619a13004a943d93-ukpnjsokhl.chromatic.com/?path=/docs/components-alert--docs)) :
related to Action Button: `rightIconBtn`, `leftIconBtn`, `AriaLabelBtn`
related to Link Button: `internalLink`,  `externalLink` , `rightIconLink`,  `leftIconLink`,  `AriaLabelLink`

### ❓ Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] 📦 New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there any PR to sync with ? -->
<!--- The component exists on old Prestashop UIKit ? Please create pull request on [migrating documentation](https://github.com/PrestaShopCorp/devdocs.uikit.prestashop.com) to help for migration.  -->

### 📝 Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes
- [ ] The component exists on old Prestashop UIKit and my pull request on [migrating documentation](https://github.com/PrestaShopCorp/devdocs.uikit.prestashop.com) is accepted.
