### PR TITLE
fix: [Skeleton] #395 - display icons for img/video/graph variants

### DIFF
--- a/docs/stories/docs/TailwindPreset.mdx
+++ b/docs/stories/docs/TailwindPreset.mdx
@@ -130,7 +130,7 @@ Congratulations you can now use all the tailwind classes used in the library
   fontFamily: {
     primary: ['IBM Plex Sans', 'Verdana', 'Arial', 'sans-serif'],
     secondary: ['Prestafont', 'Verdana', 'Arial', 'sans-serif'],
-    materialIcons: ['Material Icons Round']
+    materialIcons: ['Material Symbols Rounded']
   },
   fontSize: {
     xs: ['0.75rem', { lineHeight: '1.125rem' }],

--- a/packages/components/skeleton-loader/src/skeleton-loader.vue
+++ b/packages/components/skeleton-loader/src/skeleton-loader.vue
@@ -1,7 +1,7 @@
 <template>
   <component
     :is="tag"
-    class="puik-skeleton-loader material-icons-round"
+    class="puik-skeleton-loader"
     :class="[`puik-skeleton-loader--${variant}`]"
     :style="{ width, height }"
   />

--- a/packages/theme/src/puik-skeleton-loader.scss
+++ b/packages/theme/src/puik-skeleton-loader.scss
@@ -1,5 +1,5 @@
 .puik-skeleton-loader {
-  @apply rounded w-full text-primary-500 text-2xl;
+  @apply font-materialIcons rounded w-full text-primary-500 text-2xl;
 
   background: linear-gradient(
     90deg,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### ❓ Types of changes

Replace Material Icons by Material Symbols class for Skeleton component (fix #395)

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] 📦 New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there any PR to sync with ? -->
<!--- The component exists on old Prestashop UIKit ? Please create pull request on [migrating documentation](https://github.com/PrestaShopCorp/devdocs.uikit.prestashop.com) to help for migration.  -->

### 📝 Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes
- [ ] The component exists on old Prestashop UIKit and my pull request on [migrating documentation](https://github.com/PrestaShopCorp/devdocs.uikit.prestashop.com) is accepted.
