### PR TITLE
fix: [tooltip] related  #451 - refato max-width prop

### DIFF
--- a/packages/components/tooltip/src/tooltip.vue
+++ b/packages/components/tooltip/src/tooltip.vue
@@ -28,7 +28,7 @@
         'puik-tooltip__tip',
       { 'puik-tooltip--visible': isVisible }
       ]"
-      :style="{ 'z-index': isVisible ? zindex : -1, 'max-width': maxWidth }"
+      :style="{ 'z-index': isVisible ? zindex : -1, 'max-width': maxWidth ? `${maxWidth}px` : 'max-content' }"
       aria-live="polite"
       :aria-hidden="!isVisible"
       @mouseover="stayVisible"

--- a/packages/components/tooltip/stories/tooltip.stories.ts
+++ b/packages/components/tooltip/stories/tooltip.stories.ts
@@ -48,10 +48,10 @@ export default {
     },
     maxWidth: {
       control: 'text',
-      description: 'Set a max-width for the tooltip',
+      description: 'Sets a maximum width for the tooltip (in px)',
       table: {
         defaultValue: {
-          summary: 'undefined'
+          summary: 'max-content'
         }
       }
     },

--- a/packages/components/tooltip/test/tooltip.spec.ts
+++ b/packages/components/tooltip/test/tooltip.spec.ts
@@ -86,7 +86,7 @@ describe('Tooltip tests', () => {
 
   it('should have a custom max-width', async () => {
     factory(
-      { maxWidth: '200px' },
+      { maxWidth: '200' },
       {
         slots: {
           default: '<button>Hover me</button>'
@@ -119,7 +119,7 @@ describe('Tooltip tests', () => {
 
   it('should apply custom styles to tooltip', async () => {
     factory(
-      { maxWidth: '300px', zindex: 2000 },
+      { maxWidth: '300', zindex: 2000 },
       {
         slots: {
           default: '<button>Hover me</button>'


### PR DESCRIPTION
### Tooltip - max-width prop

- [x] set max-width prop in px 
- [x] default value to max-content
- [x] update tooltip story accordingly

<!--- Provide a general summary of your changes in the title above -->

### ❓ Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] 📦 New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there any PR to sync with ? -->
<!--- The component exists on old Prestashop UIKit ? Please create pull request on [migrating documentation](https://github.com/PrestaShopCorp/devdocs.uikit.prestashop.com) to help for migration.  -->

### 📝 Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes
- [ ] The component exists on old Prestashop UIKit and my pull request on [migrating documentation](https://github.com/PrestaShopCorp/devdocs.uikit.prestashop.com) is accepted.
