### PR TITLE
fix: sortablejs-vue3 import

### DIFF
--- a/packages/components/sortable-list/src/sortable-list.vue
+++ b/packages/components/sortable-list/src/sortable-list.vue
@@ -94,6 +94,7 @@
 </template>
 
 <script setup lang="ts">
+import { nextTick, ref } from 'vue';
 import {
   type SortableListProps,
   type SortableListEmits,
@@ -103,8 +104,8 @@ import {
   , PuikSortableListTag
 } from './sortable-list';
 import { PuikIcon } from '@prestashopcorp/puik-components';
-import { Sortable } from 'sortablejs-vue3';
-import { nextTick, ref } from 'vue';
+import * as SortableJSVue3 from 'sortablejs-vue3';
+const Sortable = SortableJSVue3.Sortable;
 
 defineOptions({
   name: 'PuikSortableList'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### ❓ Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] 📦 New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there any PR to sync with ? -->
<!--- The component exists on old Prestashop UIKit ? Please create pull request on [migrating documentation](https://github.com/PrestaShopCorp/devdocs.uikit.prestashop.com) to help for migration.  -->
Fix https://github.com/PrestaShopCorp/puik/issues/480
Cannot install PUIK 2.6.0 because of this error: 
```
import { Sortable as K } from "sortablejs-vue3";
         ^^^^^^^^
```
### 📝 Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes
- [ ] The component exists on old Prestashop UIKit and my pull request on [migrating documentation](https://github.com/PrestaShopCorp/devdocs.uikit.prestashop.com) is accepted.
