### PR TITLE
docs: [tab-navigation][storybook] fix #493

### DIFF
--- a/packages/components/tab-navigation/stories/tab-navigation.stories.ts
+++ b/packages/components/tab-navigation/stories/tab-navigation.stories.ts
@@ -22,7 +22,7 @@ export default {
     defaultPosition: {
       description:
         'Default position of the selected tab. NB: the minimum value cannot be less than 1 ',
-      control: { type: 'number', min: 1 },
+      control: { type: 'number', min: 1, max: 3 },
       table: {
         type: {
           summary: 'number'
@@ -106,7 +106,7 @@ const Template: StoryFn = (args: Args) => ({
     return { tabs, args };
   },
   template: `
-<puik-tab-navigation :name="args.name" :default-position="args.defaultPosition">
+<puik-tab-navigation :key="args.defaultPosition" :name="args.name" :default-position="args.defaultPosition">
   <puik-tab-navigation-group-titles :aria-label="args.ariaLabel">
     <template v-for="(tab, index) in tabs" :key="index">
       <puik-tab-navigation-title :position="index + 1" :disabled="tab?.disabled">
@@ -141,7 +141,7 @@ export const Default: StoryObj = {
       source: {
         code: `
 <!--VueJS Snippet-->
-<puik-tab-navigation :name="args.name" :default-position="args.defaultPosition">
+<puik-tab-navigation :key="args.defaultPosition" :name="args.name" :default-position="args.defaultPosition">
   <puik-tab-navigation-group-titles :aria-label="args.ariaLabel">
     <template v-for="(tab, index) in tabs" :key="index">
       <puik-tab-navigation-title :position="index + 1" :disabled="tab?.disabled">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### ❓ Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] 📦 New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

fix #493
Re-render component when defaultPosition prop changed

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- Is there any PR to sync with ? -->
<!--- The component exists on old Prestashop UIKit ? Please create pull request on [migrating documentation](https://github.com/PrestaShopCorp/devdocs.uikit.prestashop.com) to help for migration.  -->

### 📝 Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes
- [ ] The component exists on old Prestashop UIKit and my pull request on [migrating documentation](https://github.com/PrestaShopCorp/devdocs.uikit.prestashop.com) is accepted.
