### PR TITLE
fix: use pnpm pack to resolve workspace:* protocol in published packages

### DIFF
--- a/.github/workflows/cd-publish-release.yml
+++ b/.github/workflows/cd-publish-release.yml
@@ -58,7 +58,9 @@ jobs:
                 fi
                 echo "Publishing $NAME@$VERSION"
                 cd "$pkg"
-                npm publish --access public --provenance
+                TARBALL=$(pnpm pack 2>/dev/null | tail -1)
+                npm publish "$TARBALL" --access public --provenance
+                rm -f "$TARBALL"
                 cd "$GITHUB_WORKSPACE"
               fi
             fi


### PR DESCRIPTION
## Summary

- Fixes `EUNSUPPORTEDPROTOCOL` error when running `npm install @prestashopcorp/puik-*` in consumer apps
- Root cause: `npm publish` was publishing packages with `workspace:*` references intact (e.g. `"@prestashopcorp/puik-theme": "workspace:*"`), which npm does not understand
- Fix: replace `npm publish` with `pnpm pack` + `npm publish <tarball>` — `pnpm pack` automatically substitutes `workspace:*` with the actual resolved version before creating the archive; `npm publish` then uploads that clean tarball using OIDC (Trusted Publisher)

## Why not `pnpm publish`?

As discussed previously, pnpm does not support OIDC/Trusted Publishing (see pnpm/pnpm#9812). `npm publish` must be used for the OIDC step, but `pnpm pack` handles the workspace protocol substitution beforehand.

## Test plan

- [ ] Trigger a release and verify no `workspace:*` references appear in the published `package.json` on npmjs.com
- [ ] Run `npm install @prestashopcorp/puik-components @prestashopcorp/puik-theme @prestashopcorp/puik-resolver` in a fresh Vue app and confirm it succeeds without `EUNSUPPORTEDPROTOCOL` error

Closes #521