### PR TITLE
chore: bump versions to 2.8.1 for release

### DIFF
--- a/docs/storybook/CHANGELOG.md
+++ b/docs/storybook/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @prestashopcorp/puik-docs
 
+## 1.8.2
+
+### Patch Changes
+
+- fix npm publish version tag
+- Updated dependencies
+  - @prestashopcorp/puik-web-components@2.8.1
+  - @prestashopcorp/puik-components@2.8.1
+  - @prestashopcorp/puik-resolver@9.0.1
+  - @prestashopcorp/puik-theme@2.8.1
+
 ## 1.8.1
 
 ### Patch Changes

--- a/docs/storybook/package.json
+++ b/docs/storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@prestashopcorp/puik-docs",
   "description": "PUIK docs - Storybook documentation.",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "private": true,
   "main": "index.js",
   "license": "MIT",

--- a/docs/vitepress/CHANGELOG.md
+++ b/docs/vitepress/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @prestashopcorp/puik-user-docs
 
+## 1.3.2
+
+### Patch Changes
+
+- fix npm publish version tag
+- Updated dependencies
+  - @prestashopcorp/puik-web-components@2.8.1
+  - @prestashopcorp/puik-components@2.8.1
+  - @prestashopcorp/puik-resolver@9.0.1
+  - @prestashopcorp/puik-theme@2.8.1
+
 ## 1.3.1
 
 ### Patch Changes

--- a/docs/vitepress/package.json
+++ b/docs/vitepress/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@prestashopcorp/puik-user-docs",
   "description": "PUIK user documentation - with Vitepress.",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "main": "index.js",
   "license": "MIT",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @prestashopcorp/puik-components
 
+## 2.8.1
+
+### Patch Changes
+
+- fix npm publish version tag
+- Updated dependencies
+  - @prestashopcorp/puik-theme@2.8.1
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@prestashopcorp/puik-components",
   "description": "PUIK Vue 3 components library.",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "author": "Prestashop",
   "license": "MIT",
   "type": "module",

--- a/packages/locale/CHANGELOG.md
+++ b/packages/locale/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @prestashopcorp/puik-locale
 
+## 2.5.1
+
+### Patch Changes
+
+- fix npm publish version tag
+
 ## 2.5.0
 
 ### Minor Changes

--- a/packages/locale/package.json
+++ b/packages/locale/package.json
@@ -2,6 +2,6 @@
   "name": "@prestashopcorp/puik-locale",
   "description": "PUIK locale - Translations feature.",
   "private": true,
-  "version": "2.5.0",
+  "version": "2.5.1",
   "license": "MIT"
 }

--- a/packages/puik/CHANGELOG.md
+++ b/packages/puik/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @prestashopcorp/puik
 
+## 2.8.1
+
+### Patch Changes
+
+- fix npm publish version tag
+- Updated dependencies
+  - @prestashopcorp/puik-web-components@2.8.1
+  - @prestashopcorp/puik-components@2.8.1
+  - @prestashopcorp/puik-resolver@9.0.1
+  - @prestashopcorp/puik-theme@2.8.1
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/puik/package.json
+++ b/packages/puik/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@prestashopcorp/puik",
   "description": "PUIK - This includes all public packages of PrestaShop UI kit.",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "author": "Prestashop",
   "license": "MIT",
   "type": "module",

--- a/packages/resolver/CHANGELOG.md
+++ b/packages/resolver/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @prestashopcorp/puik-resolver
 
+## 9.0.1
+
+### Patch Changes
+
+- fix npm publish version tag
+- Updated dependencies
+  - @prestashopcorp/puik-components@2.8.1
+  - @prestashopcorp/puik-theme@2.8.1
+
 ## 9.0.0
 
 ### Patch Changes

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@prestashopcorp/puik-resolver",
   "description": "PUIK resolver - For unplugin-vue-components.",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "author": "Prestashop",
   "license": "MIT",
   "type": "module",

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @prestashopcorp/puik-theme
 
+## 2.8.1
+
+### Patch Changes
+
+- fix npm publish version tag
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@prestashopcorp/puik-theme",
   "description": "PUIK theme - CSS classes of Prestashop UI Kit.",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "author": "Prestashop",
   "license": "MIT",
   "main": "./dist/index.css",

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @prestashopcorp/puik-utils
 
+## 2.4.1
+
+### Patch Changes
+
+- fix npm publish version tag
+
 ## 2.4.0
 
 ### Minor Changes

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@prestashopcorp/puik-utils",
   "description": "PUIK utils - Set of useful functions used by PrestaShop UI Kit.",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "private": true,
   "license": "MIT"
 }

--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @prestashopcorp/puik-web-components
 
+## 2.8.1
+
+### Patch Changes
+
+- fix npm publish version tag
+- Updated dependencies
+  - @prestashopcorp/puik-components@2.8.1
+  - @prestashopcorp/puik-theme@2.8.1
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@prestashopcorp/puik-web-components",
   "description": "PUIK Web-Components library.",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "author": "Prestashop",
   "license": "MIT",
   "type": "module",

--- a/playground/CHANGELOG.md
+++ b/playground/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @prestashopcorp/puik-playground
 
+## 0.3.2
+
+### Patch Changes
+
+- fix npm publish version tag
+- Updated dependencies
+  - @prestashopcorp/puik-web-components@2.8.1
+  - @prestashopcorp/puik-components@2.8.1
+  - @prestashopcorp/puik-resolver@9.0.1
+  - @prestashopcorp/puik-theme@2.8.1
+
 ## 0.3.1
 
 ### Patch Changes

--- a/playground/package.json
+++ b/playground/package.json
@@ -2,7 +2,7 @@
   "name": "@prestashopcorp/puik-playground",
   "description": "PUIK playground - For testing components.",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "scripts": {
     "dev": "vite --force && pnpm --filter @prestashopcorp/puik-theme dev",


### PR DESCRIPTION
Patch release to fix workspace:* protocol in published packages causing npm install to fail for consumers (closes #521).
